### PR TITLE
Use --no-configuration-cache for release process

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -22,4 +22,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Publish to Sonatype Snapshot
-        run: ./gradlew publishAllPublicationsToSonatypeSnapshotRepository -PGPG_SIGNING_REQUIRED
+        run: ./gradlew publishAllPublicationsToSonatypeSnapshotRepository -PGPG_SIGNING_REQUIRED --no-configuration-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,4 +22,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Publish to Sonatype Staging
-        run: ./gradlew publishAllPublicationsToSonatypeStagingRepository -PGPG_SIGNING_REQUIRED
+        run: ./gradlew publishAllPublicationsToSonatypeStagingRepository -PGPG_SIGNING_REQUIRED --no-configuration-cache


### PR DESCRIPTION
We face cache issues while releasing to sonatype.