### PR TITLE
Make kotlinx-datetime as api dependency

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -30,10 +30,10 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(libs.kotlinx.serialization)
-                implementation(libs.kotlinx.datetime)
                 implementation(libs.ktor.core)
                 implementation(libs.ktor.serialization)
                 implementation(libs.ktor.client.negotiation)
+                api(libs.kotlinx.datetime)
             }
         }
         val commonTest by getting {


### PR DESCRIPTION
Closes: https://github.com/ioki-mobility/kmp-passenger-api/issues/3