### PR TITLE
Add tests for mapSuccess and mapApiError

### DIFF
--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/IokiService.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/IokiService.kt
@@ -859,48 +859,43 @@ private class DefaultIokiService(
 }
 
 @Suppress("UNCHECKED_CAST")
-private suspend inline fun <reified R, reified T> mapSuccess(successfulResponse: HttpResponse): Result.Success<T> {
+internal suspend inline fun <reified R, reified T> mapSuccess(successfulResponse: HttpResponse): Result.Success<T> {
     val body = successfulResponse.body<R>()
     val meta = (body as? ApiBody<*>)?.meta
-    val data =
-        when (body) {
-            null -> Unit as? T // For Void (no content) body
-            is T -> body
-            is ApiBody<*> ->
-                when {
-                    body.data is T -> body.data
-                    T::class == String::class -> body.data.toString()
-                    else -> null
-                }
+    val data = when (body) {
+        null -> Unit as? T // For Void (no content) body
+        is T -> body
+        is ApiBody<*> ->
+            when {
+                body.data is T -> body.data
+                T::class == String::class -> body.data.toString()
+                else -> null
+            }
 
-            else -> null
-        } ?: throw IllegalArgumentException("Failed to convert body '$body' to type ${T::class}")
+        else -> null
+    } ?: throw IllegalArgumentException("Failed to convert body '$body' to type ${T::class}")
     return Result.Success(data, meta) as Result.Success<T>
 }
 
-private suspend fun mapApiError(
+internal suspend fun mapApiError(
     failedResponse: HttpResponse,
     interceptors: Collection<ApiErrorInterceptor>,
 ): Result.Error.Api {
-    return try {
-        val apiErrorBody = failedResponse.body<ApiErrorBody>()
-        val code = failedResponse.status.value
-        // 502 happens when Google runs internal tests. Catching it here prevents it from being reported as an error
-        val apiErrors =
-            if (code == com.ioki.passenger.api.result.HttpStatusCode.BAD_GATEWAY_502) {
-                emptyList()
-            } else {
-                apiErrorBody.apiErrors
-            }
-
-        interceptors.forEach { interceptor ->
-            if (interceptor.intercept(apiErrors, code)) {
-                return Result.Error.Api.Intercepted(apiErrors, code)
-            }
+    val apiErrorBody = failedResponse.body<ApiErrorBody?>()
+    val code = failedResponse.status.value
+    // 502 happens when Google runs internal tests. Catching it here prevents it from being reported as an error
+    val apiErrors =
+        if (code == com.ioki.passenger.api.result.HttpStatusCode.BAD_GATEWAY_502) {
+            emptyList()
+        } else {
+            apiErrorBody?.apiErrors ?: emptyList()
         }
 
-        Result.Error.Api.Generic(apiErrors, code)
-    } catch (e: Throwable) {
-        Result.Error.Api.Generic(emptyList(), failedResponse.status.value)
+    interceptors.forEach { interceptor ->
+        if (interceptor.intercept(apiErrors, code)) {
+            return Result.Error.Api.Intercepted(apiErrors, code)
+        }
     }
+
+    return Result.Error.Api.Generic(apiErrors, code)
 }

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/IokiService.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/IokiService.kt
@@ -75,6 +75,7 @@ import com.ioki.passenger.api.models.ApiUpdateUserRequest
 import com.ioki.passenger.api.models.ApiUserFlagsRequest
 import com.ioki.passenger.api.models.ApiUserNotificationSettingsResponse
 import com.ioki.passenger.api.models.ApiVenueResponse
+import com.ioki.passenger.api.result.HttpStatusCode
 import com.ioki.passenger.api.result.Result
 import io.ktor.client.call.body
 import io.ktor.client.statement.HttpResponse
@@ -884,12 +885,7 @@ internal suspend fun mapApiError(
     val apiErrorBody = failedResponse.body<ApiErrorBody?>()
     val code = failedResponse.status.value
     // 502 happens when Google runs internal tests. Catching it here prevents it from being reported as an error
-    val apiErrors =
-        if (code == com.ioki.passenger.api.result.HttpStatusCode.BAD_GATEWAY_502) {
-            emptyList()
-        } else {
-            apiErrorBody?.apiErrors ?: emptyList()
-        }
+    val apiErrors = if (code == HttpStatusCode.BAD_GATEWAY_502) emptyList() else apiErrorBody?.apiErrors ?: emptyList()
 
     interceptors.forEach { interceptor ->
         if (interceptor.intercept(apiErrors, code)) {

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/FakeHttpClient.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/FakeHttpClient.kt
@@ -11,10 +11,8 @@ import io.ktor.http.headers
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.ByteReadChannel
 
-internal fun createHttpMockClient(
-    statusCode: HttpStatusCode,
-    content: ByteReadChannel,
-): HttpClient {
+@Suppress("FunctionName")
+internal fun FakeHttpClient(statusCode: HttpStatusCode, content: ByteReadChannel): HttpClient {
     val mockEngine = MockEngine { _ ->
         respond(
             content = content,

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/Helpers.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/Helpers.kt
@@ -1,0 +1,34 @@
+package com.ioki.passenger.api
+
+import com.ioki.passenger.api.internal.utils.createJson
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headers
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
+
+internal fun createHttpClient(
+    statusCode: HttpStatusCode,
+    content: ByteReadChannel,
+): HttpClient {
+    val mockEngine = MockEngine { _ ->
+        respond(
+            content = content,
+            status = statusCode,
+            headers = headers {
+                append(HttpHeaders.ContentType, "application/json")
+                append(HttpHeaders.Date, "Sun, 06 Nov 1994 08:49:37 GMT")
+            },
+        )
+    }
+
+    return HttpClient(mockEngine) {
+        install(ContentNegotiation) {
+            json(createJson())
+        }
+    }
+}

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/Helpers.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/Helpers.kt
@@ -11,7 +11,7 @@ import io.ktor.http.headers
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.ByteReadChannel
 
-internal fun createHttpClient(
+internal fun createHttpMockClient(
     statusCode: HttpStatusCode,
     content: ByteReadChannel,
 ): HttpClient {

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/MapApiErrorTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/MapApiErrorTest.kt
@@ -4,14 +4,12 @@ import com.ioki.passenger.api.models.ApiErrorBody
 import com.ioki.passenger.api.result.Result
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
-import io.ktor.util.InternalAPI
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-@InternalAPI
 internal class MapApiErrorTest {
 
     @Test

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/MapApiErrorTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/MapApiErrorTest.kt
@@ -1,0 +1,105 @@
+package com.ioki.passenger.api
+
+import com.ioki.passenger.api.models.ApiErrorBody
+import com.ioki.passenger.api.result.Result
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.util.InternalAPI
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.expect
+
+@InternalAPI
+internal class MapApiErrorTest {
+
+    @Test
+    fun `mapApiError returns version outdated error`() = runTest {
+        val content = ByteReadChannel(
+            text = """
+                    {
+                      "api_errors": [
+                        { "message": "App version is outdated", "code": "version_outdated" }
+                      ]
+                    }
+                """,
+        )
+
+        val fakeHttpClient = createHttpClient(HttpStatusCode.NotAcceptable, content)
+        val fakeResponse = fakeHttpClient.get("https://127.0.0.1")
+
+        val fakeApiErrorInterceptor = object : ApiErrorInterceptor {
+            override fun intercept(apiErrors: List<ApiErrorBody.ApiError>, httpResponseCode: Int): Boolean {
+                val isAppVersionOutdated = apiErrors.any { it.code == "version_outdated" }
+                val isNotAcceptable = httpResponseCode == HttpStatusCode.NotAcceptable.value
+                return isAppVersionOutdated && isNotAcceptable
+            }
+        }
+
+        mapApiError(fakeResponse, listOf(fakeApiErrorInterceptor)).let { result ->
+            assertTrue { result is Result.Error.Api.Intercepted }
+            assertEquals(HttpStatusCode.NotAcceptable.value, result.httpStatusCode)
+        }
+    }
+
+    @Test
+    fun `mapApiError returns unauthorized error`() = runTest {
+        val content = ByteReadChannel.Empty
+
+        val fakeHttpClient = createHttpClient(HttpStatusCode.Unauthorized, content)
+        val fakeResponse = fakeHttpClient.get("https://127.0.0.1")
+
+        val fakeApiErrorInterceptor = object : ApiErrorInterceptor {
+            override fun intercept(apiErrors: List<ApiErrorBody.ApiError>, httpResponseCode: Int): Boolean {
+                return httpResponseCode == HttpStatusCode.Unauthorized.value
+            }
+        }
+
+        mapApiError(fakeResponse, listOf(fakeApiErrorInterceptor)).let { result ->
+            assertTrue { result is Result.Error.Api.Intercepted }
+            assertEquals(HttpStatusCode.Unauthorized.value, result.httpStatusCode)
+        }
+    }
+
+    @Test
+    fun `mapApiError returns generic error`() = runTest {
+        val content = ByteReadChannel.Empty
+
+        val fakeHttpClient = createHttpClient(HttpStatusCode.BadGateway, content)
+        val fakeResponse = fakeHttpClient.get("https://127.0.0.1")
+
+        val fakeApiErrorInterceptor = object : ApiErrorInterceptor {
+            override fun intercept(apiErrors: List<ApiErrorBody.ApiError>, httpResponseCode: Int): Boolean {
+                return httpResponseCode == HttpStatusCode.Unauthorized.value
+            }
+        }
+
+        mapApiError(fakeResponse, listOf(fakeApiErrorInterceptor)).let { result ->
+            assertTrue { result is Result.Error.Api.Generic }
+            assertEquals(HttpStatusCode.BadGateway.value, result.httpStatusCode)
+        }
+    }
+
+    @Test
+    fun `mapApiError returns generic error without interceptors`() = runTest {
+        val content = ByteReadChannel(
+            text = """
+                    {
+                      "api_errors": [
+                        { "message": "App version is outdated", "code": "version_outdated" }
+                      ]
+                    }
+                """,
+        )
+
+        val fakeHttpClient = createHttpClient(HttpStatusCode.NotAcceptable, content)
+        val fakeResponse = fakeHttpClient.get("https://127.0.0.1")
+
+        mapApiError(fakeResponse, listOf()).let { result ->
+            assertTrue { result is Result.Error.Api.Generic }
+            assertEquals(HttpStatusCode.NotAcceptable.value, result.httpStatusCode)
+        }
+    }
+}

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/MapApiErrorTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/MapApiErrorTest.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import kotlin.test.expect
 
 @InternalAPI
 internal class MapApiErrorTest {
@@ -27,7 +26,7 @@ internal class MapApiErrorTest {
                 """,
         )
 
-        val fakeHttpClient = createHttpClient(HttpStatusCode.NotAcceptable, content)
+        val fakeHttpClient = createHttpMockClient(HttpStatusCode.NotAcceptable, content)
         val fakeResponse = fakeHttpClient.get("https://127.0.0.1")
 
         val fakeApiErrorInterceptor = object : ApiErrorInterceptor {
@@ -38,17 +37,16 @@ internal class MapApiErrorTest {
             }
         }
 
-        mapApiError(fakeResponse, listOf(fakeApiErrorInterceptor)).let { result ->
-            assertTrue { result is Result.Error.Api.Intercepted }
-            assertEquals(HttpStatusCode.NotAcceptable.value, result.httpStatusCode)
-        }
+        val result = mapApiError(fakeResponse, listOf(fakeApiErrorInterceptor))
+        assertTrue { result is Result.Error.Api.Intercepted }
+        assertEquals(HttpStatusCode.NotAcceptable.value, result.httpStatusCode)
     }
 
     @Test
     fun `mapApiError returns unauthorized error`() = runTest {
         val content = ByteReadChannel.Empty
 
-        val fakeHttpClient = createHttpClient(HttpStatusCode.Unauthorized, content)
+        val fakeHttpClient = createHttpMockClient(HttpStatusCode.Unauthorized, content)
         val fakeResponse = fakeHttpClient.get("https://127.0.0.1")
 
         val fakeApiErrorInterceptor = object : ApiErrorInterceptor {
@@ -57,17 +55,16 @@ internal class MapApiErrorTest {
             }
         }
 
-        mapApiError(fakeResponse, listOf(fakeApiErrorInterceptor)).let { result ->
-            assertTrue { result is Result.Error.Api.Intercepted }
-            assertEquals(HttpStatusCode.Unauthorized.value, result.httpStatusCode)
-        }
+        val result = mapApiError(fakeResponse, listOf(fakeApiErrorInterceptor))
+        assertTrue { result is Result.Error.Api.Intercepted }
+        assertEquals(HttpStatusCode.Unauthorized.value, result.httpStatusCode)
     }
 
     @Test
     fun `mapApiError returns generic error`() = runTest {
         val content = ByteReadChannel.Empty
 
-        val fakeHttpClient = createHttpClient(HttpStatusCode.BadGateway, content)
+        val fakeHttpClient = createHttpMockClient(HttpStatusCode.BadGateway, content)
         val fakeResponse = fakeHttpClient.get("https://127.0.0.1")
 
         val fakeApiErrorInterceptor = object : ApiErrorInterceptor {
@@ -76,10 +73,9 @@ internal class MapApiErrorTest {
             }
         }
 
-        mapApiError(fakeResponse, listOf(fakeApiErrorInterceptor)).let { result ->
-            assertTrue { result is Result.Error.Api.Generic }
-            assertEquals(HttpStatusCode.BadGateway.value, result.httpStatusCode)
-        }
+        val result = mapApiError(fakeResponse, listOf(fakeApiErrorInterceptor))
+        assertTrue { result is Result.Error.Api.Generic }
+        assertEquals(HttpStatusCode.BadGateway.value, result.httpStatusCode)
     }
 
     @Test
@@ -94,12 +90,11 @@ internal class MapApiErrorTest {
                 """,
         )
 
-        val fakeHttpClient = createHttpClient(HttpStatusCode.NotAcceptable, content)
+        val fakeHttpClient = createHttpMockClient(HttpStatusCode.NotAcceptable, content)
         val fakeResponse = fakeHttpClient.get("https://127.0.0.1")
 
-        mapApiError(fakeResponse, listOf()).let { result ->
-            assertTrue { result is Result.Error.Api.Generic }
-            assertEquals(HttpStatusCode.NotAcceptable.value, result.httpStatusCode)
-        }
+        val result = mapApiError(fakeResponse, listOf())
+        assertTrue { result is Result.Error.Api.Generic }
+        assertEquals(HttpStatusCode.NotAcceptable.value, result.httpStatusCode)
     }
 }

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/MapApiErrorTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/MapApiErrorTest.kt
@@ -24,7 +24,7 @@ internal class MapApiErrorTest {
                 """,
         )
 
-        val fakeHttpClient = createHttpMockClient(HttpStatusCode.NotAcceptable, content)
+        val fakeHttpClient = FakeHttpClient(HttpStatusCode.NotAcceptable, content)
         val fakeResponse = fakeHttpClient.get("https://127.0.0.1")
 
         val fakeApiErrorInterceptor = object : ApiErrorInterceptor {
@@ -44,7 +44,7 @@ internal class MapApiErrorTest {
     fun `mapApiError returns unauthorized error`() = runTest {
         val content = ByteReadChannel.Empty
 
-        val fakeHttpClient = createHttpMockClient(HttpStatusCode.Unauthorized, content)
+        val fakeHttpClient = FakeHttpClient(HttpStatusCode.Unauthorized, content)
         val fakeResponse = fakeHttpClient.get("https://127.0.0.1")
 
         val fakeApiErrorInterceptor = object : ApiErrorInterceptor {
@@ -62,7 +62,7 @@ internal class MapApiErrorTest {
     fun `mapApiError returns generic error`() = runTest {
         val content = ByteReadChannel.Empty
 
-        val fakeHttpClient = createHttpMockClient(HttpStatusCode.BadGateway, content)
+        val fakeHttpClient = FakeHttpClient(HttpStatusCode.BadGateway, content)
         val fakeResponse = fakeHttpClient.get("https://127.0.0.1")
 
         val fakeApiErrorInterceptor = object : ApiErrorInterceptor {
@@ -88,7 +88,7 @@ internal class MapApiErrorTest {
                 """,
         )
 
-        val fakeHttpClient = createHttpMockClient(HttpStatusCode.NotAcceptable, content)
+        val fakeHttpClient = FakeHttpClient(HttpStatusCode.NotAcceptable, content)
         val fakeResponse = fakeHttpClient.get("https://127.0.0.1")
 
         val result = mapApiError(fakeResponse, listOf())

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/MapApiErrorTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/MapApiErrorTest.kt
@@ -23,10 +23,8 @@ internal class MapApiErrorTest {
                     }
                 """,
         )
-
         val fakeHttpClient = FakeHttpClient(HttpStatusCode.NotAcceptable, content)
         val fakeResponse = fakeHttpClient.get("https://127.0.0.1")
-
         val fakeApiErrorInterceptor = object : ApiErrorInterceptor {
             override fun intercept(apiErrors: List<ApiErrorBody.ApiError>, httpResponseCode: Int): Boolean {
                 val isAppVersionOutdated = apiErrors.any { it.code == "version_outdated" }
@@ -36,6 +34,7 @@ internal class MapApiErrorTest {
         }
 
         val result = mapApiError(fakeResponse, listOf(fakeApiErrorInterceptor))
+
         assertTrue { result is Result.Error.Api.Intercepted }
         assertEquals(HttpStatusCode.NotAcceptable.value, result.httpStatusCode)
     }
@@ -43,10 +42,8 @@ internal class MapApiErrorTest {
     @Test
     fun `mapApiError returns unauthorized error`() = runTest {
         val content = ByteReadChannel.Empty
-
         val fakeHttpClient = FakeHttpClient(HttpStatusCode.Unauthorized, content)
         val fakeResponse = fakeHttpClient.get("https://127.0.0.1")
-
         val fakeApiErrorInterceptor = object : ApiErrorInterceptor {
             override fun intercept(apiErrors: List<ApiErrorBody.ApiError>, httpResponseCode: Int): Boolean {
                 return httpResponseCode == HttpStatusCode.Unauthorized.value
@@ -54,6 +51,7 @@ internal class MapApiErrorTest {
         }
 
         val result = mapApiError(fakeResponse, listOf(fakeApiErrorInterceptor))
+
         assertTrue { result is Result.Error.Api.Intercepted }
         assertEquals(HttpStatusCode.Unauthorized.value, result.httpStatusCode)
     }
@@ -61,10 +59,8 @@ internal class MapApiErrorTest {
     @Test
     fun `mapApiError returns generic error`() = runTest {
         val content = ByteReadChannel.Empty
-
         val fakeHttpClient = FakeHttpClient(HttpStatusCode.BadGateway, content)
         val fakeResponse = fakeHttpClient.get("https://127.0.0.1")
-
         val fakeApiErrorInterceptor = object : ApiErrorInterceptor {
             override fun intercept(apiErrors: List<ApiErrorBody.ApiError>, httpResponseCode: Int): Boolean {
                 return httpResponseCode == HttpStatusCode.Unauthorized.value
@@ -72,6 +68,7 @@ internal class MapApiErrorTest {
         }
 
         val result = mapApiError(fakeResponse, listOf(fakeApiErrorInterceptor))
+
         assertTrue { result is Result.Error.Api.Generic }
         assertEquals(HttpStatusCode.BadGateway.value, result.httpStatusCode)
     }
@@ -87,11 +84,11 @@ internal class MapApiErrorTest {
                     }
                 """,
         )
-
         val fakeHttpClient = FakeHttpClient(HttpStatusCode.NotAcceptable, content)
         val fakeResponse = fakeHttpClient.get("https://127.0.0.1")
 
         val result = mapApiError(fakeResponse, listOf())
+
         assertTrue { result is Result.Error.Api.Generic }
         assertEquals(HttpStatusCode.NotAcceptable.value, result.httpStatusCode)
     }

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/MapSuccessTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/MapSuccessTest.kt
@@ -50,7 +50,7 @@ class MapSuccessTest {
             """.trimIndent(),
         )
 
-        val fakeHttpClient = createHttpMockClient(HttpStatusCode.OK, content)
+        val fakeHttpClient = FakeHttpClient(HttpStatusCode.OK, content)
         val response = fakeHttpClient.get("https://127.0.0.1")
 
         val result = mapSuccess<ApiBody<ApiClientInfoResponse>, ApiClientInfoResponse>(response)
@@ -76,7 +76,7 @@ class MapSuccessTest {
             """.trimIndent(),
         )
 
-        val fakeHttpClient = createHttpMockClient(HttpStatusCode.OK, content)
+        val fakeHttpClient = FakeHttpClient(HttpStatusCode.OK, content)
         val response = fakeHttpClient.get("https://127.0.0.1")
 
         val result = mapSuccess<ApiClientInfoResponse, ApiClientInfoResponse>(response)
@@ -98,7 +98,7 @@ class MapSuccessTest {
             """.trimIndent(),
         )
 
-        val fakeHttpClient = createHttpMockClient(HttpStatusCode.OK, content)
+        val fakeHttpClient = FakeHttpClient(HttpStatusCode.OK, content)
         val response = fakeHttpClient.get("https://127.0.0.1")
 
         assertFailsWith<IllegalArgumentException> {

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/MapSuccessTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/MapSuccessTest.kt
@@ -49,11 +49,11 @@ class MapSuccessTest {
                 }
             """.trimIndent(),
         )
-
         val fakeHttpClient = FakeHttpClient(HttpStatusCode.OK, content)
         val response = fakeHttpClient.get("https://127.0.0.1")
 
         val result = mapSuccess<ApiBody<ApiClientInfoResponse>, ApiClientInfoResponse>(response)
+
         assertIs<Result.Success<ApiClientInfoResponse>>(result)
         assertEquals(result.data, apiClientInfoResponse)
     }
@@ -75,11 +75,11 @@ class MapSuccessTest {
                 }
             """.trimIndent(),
         )
-
         val fakeHttpClient = FakeHttpClient(HttpStatusCode.OK, content)
         val response = fakeHttpClient.get("https://127.0.0.1")
 
         val result = mapSuccess<ApiClientInfoResponse, ApiClientInfoResponse>(response)
+
         assertIs<Result.Success<ApiClientInfoResponse>>(result)
         assertEquals(result.data, apiClientInfoResponse)
     }
@@ -97,7 +97,6 @@ class MapSuccessTest {
                 }
             """.trimIndent(),
         )
-
         val fakeHttpClient = FakeHttpClient(HttpStatusCode.OK, content)
         val response = fakeHttpClient.get("https://127.0.0.1")
 

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/MapSuccessTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/MapSuccessTest.kt
@@ -1,0 +1,110 @@
+package com.ioki.passenger.api
+
+import com.ioki.passenger.api.models.ApiBody
+import com.ioki.passenger.api.models.ApiClientInfoResponse
+import com.ioki.passenger.api.result.Result
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+class MapSuccessTest {
+
+    private val apiClientInfoResponse = ApiClientInfoResponse(
+        distributionUrl = "https://example.com/distribution",
+        termsOfServiceUrl = "https://example.com/terms",
+        privacyPolicyUrl = "https://example.com/privacy",
+        imprintUrl = "https://example.com/imprint",
+        helpUrl = "https://example.com/help",
+        supportEmail = "support@example.com",
+        supportWebsiteUrl = "https://example.com/support",
+        supportPhoneNumber = "+1234567890",
+        smsPhoneNumber = "+0987654321",
+    )
+
+    @Test
+    fun `mapSuccess returns Result with ApiClientInfoResponse`() = runTest {
+        val content = ByteReadChannel(
+            text = """
+                {
+                  "data": {
+                    "distribution_url": "https://example.com/distribution",
+                    "terms_of_service_url": "https://example.com/terms",
+                    "privacy_policy_url": "https://example.com/privacy",
+                    "imprint_url": "https://example.com/imprint",
+                    "help_url": "https://example.com/help",
+                    "support_email": "support@example.com",
+                    "support_website_url": "https://example.com/support",
+                    "support_phone_number": "+1234567890",
+                    "sms_support_number": "+0987654321"
+                  },
+                  "meta": {
+                    "page": 1,
+                    "last_page": true
+                  }
+                }
+            """.trimIndent(),
+        )
+
+        val fakeHttpClient = createHttpClient(HttpStatusCode.OK, content)
+        val response = fakeHttpClient.get("https://127.0.0.1")
+
+        mapSuccess<ApiBody<ApiClientInfoResponse>, ApiClientInfoResponse>(response).let { result ->
+            assertIs<Result.Success<ApiClientInfoResponse>>(result)
+            assertEquals(result.data, apiClientInfoResponse)
+        }
+    }
+
+    @Test
+    fun `mapSuccess returns Result with ApiClientInfoResponse without ApiBody`() = runTest {
+        val content = ByteReadChannel(
+            text = """
+                {
+                  "distribution_url": "https://example.com/distribution",
+                   "terms_of_service_url": "https://example.com/terms",
+                   "privacy_policy_url": "https://example.com/privacy",
+                   "imprint_url": "https://example.com/imprint",
+                   "help_url": "https://example.com/help",
+                   "support_email": "support@example.com",
+                   "support_website_url": "https://example.com/support",
+                   "support_phone_number": "+1234567890",
+                   "sms_support_number": "+0987654321"
+                }
+            """.trimIndent(),
+        )
+
+        val fakeHttpClient = createHttpClient(HttpStatusCode.OK, content)
+        val response = fakeHttpClient.get("https://127.0.0.1")
+
+        mapSuccess<ApiClientInfoResponse, ApiClientInfoResponse>(response).let { result ->
+            assertIs<Result.Success<ApiClientInfoResponse>>(result)
+            assertEquals(result.data, apiClientInfoResponse)
+        }
+    }
+
+    @Test
+    fun `mapSuccess throws exception`() = runTest {
+        val content = ByteReadChannel(
+            text = """
+                {
+                  "data": null,
+                  "meta": {
+                    "page": 1,
+                    "last_page": true
+                  }
+                }
+            """.trimIndent(),
+        )
+
+        val fakeHttpClient = createHttpClient(HttpStatusCode.OK, content)
+        val response = fakeHttpClient.get("https://127.0.0.1")
+
+        assertFailsWith<IllegalArgumentException> {
+            mapSuccess<ApiBody<ApiClientInfoResponse?>, ApiClientInfoResponse>(response)
+        }
+    }
+}

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/MapSuccessTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/MapSuccessTest.kt
@@ -50,13 +50,12 @@ class MapSuccessTest {
             """.trimIndent(),
         )
 
-        val fakeHttpClient = createHttpClient(HttpStatusCode.OK, content)
+        val fakeHttpClient = createHttpMockClient(HttpStatusCode.OK, content)
         val response = fakeHttpClient.get("https://127.0.0.1")
 
-        mapSuccess<ApiBody<ApiClientInfoResponse>, ApiClientInfoResponse>(response).let { result ->
-            assertIs<Result.Success<ApiClientInfoResponse>>(result)
-            assertEquals(result.data, apiClientInfoResponse)
-        }
+        val result = mapSuccess<ApiBody<ApiClientInfoResponse>, ApiClientInfoResponse>(response)
+        assertIs<Result.Success<ApiClientInfoResponse>>(result)
+        assertEquals(result.data, apiClientInfoResponse)
     }
 
     @Test
@@ -77,13 +76,12 @@ class MapSuccessTest {
             """.trimIndent(),
         )
 
-        val fakeHttpClient = createHttpClient(HttpStatusCode.OK, content)
+        val fakeHttpClient = createHttpMockClient(HttpStatusCode.OK, content)
         val response = fakeHttpClient.get("https://127.0.0.1")
 
-        mapSuccess<ApiClientInfoResponse, ApiClientInfoResponse>(response).let { result ->
-            assertIs<Result.Success<ApiClientInfoResponse>>(result)
-            assertEquals(result.data, apiClientInfoResponse)
-        }
+        val result = mapSuccess<ApiClientInfoResponse, ApiClientInfoResponse>(response)
+        assertIs<Result.Success<ApiClientInfoResponse>>(result)
+        assertEquals(result.data, apiClientInfoResponse)
     }
 
     @Test
@@ -100,7 +98,7 @@ class MapSuccessTest {
             """.trimIndent(),
         )
 
-        val fakeHttpClient = createHttpClient(HttpStatusCode.OK, content)
+        val fakeHttpClient = createHttpMockClient(HttpStatusCode.OK, content)
         val response = fakeHttpClient.get("https://127.0.0.1")
 
         assertFailsWith<IllegalArgumentException> {


### PR DESCRIPTION
#22 
Followed by: https://github.com/ioki-mobility/kmp-passenger-api/pull/21

1. Added tests for mapSuccess and mapApiError.
2. Removed `runCatching` and use nullable `ApiErrorBody?`