### PR TITLE
Change workflow_call to workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-  workflow_call:
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
The intention is to call this job manually.
For this `workflow_dispatch` should be used.
`workflow_call` is something different.
`_call` should be used when we compose different actions and this workflow can be calle by another one. 
But this is not what we want/need.