### PR TITLE
Fix artifact name for the android target

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -76,38 +76,41 @@ group = "com.ioki"
 version = "0.0.1-SNAPSHOT"
 
 publishing {
-    publications {
+    // Workaround for the Android target
+    // withType<MavenPublication> does not work for Android target
+    afterEvaluate {
         publications.withType<MavenPublication> {
             artifactId = artifactId.replace("library", "passenger-api")
+        }
+    }
+    publications.withType<MavenPublication> {
+        pom {
+            name.set("KMP ioki Passenger API")
+            description.set("Kotlin Multiplatform ioki Passenger API")
+            url.set("https://github.com/ioki-mobility/kmp-passenger-api")
 
-            pom {
-                name.set("KMP ioki Passenger API")
-                description.set("Kotlin Multiplatform ioki Passenger API")
+            licenses {
+                license {
+                    name.set("MIT")
+                    url.set("https://opensource.org/licenses/MIT")
+                }
+            }
+            organization {
+                name.set("ioki")
+                url.set("https://ioki.com")
+            }
+            developers {
+                developer {
+                    id.set("ioki")
+                    name.set("ioki Android Team")
+                    organization.set("ioki")
+                    organizationUrl.set("https://www.ioki.com")
+                }
+            }
+            scm {
                 url.set("https://github.com/ioki-mobility/kmp-passenger-api")
-
-                licenses {
-                    license {
-                        name.set("MIT")
-                        url.set("https://opensource.org/licenses/MIT")
-                    }
-                }
-                organization {
-                    name.set("ioki")
-                    url.set("https://ioki.com")
-                }
-                developers {
-                    developer {
-                        id.set("ioki")
-                        name.set("ioki Android Team")
-                        organization.set("ioki")
-                        organizationUrl.set("https://www.ioki.com")
-                    }
-                }
-                scm {
-                    url.set("https://github.com/ioki-mobility/kmp-passenger-api")
-                    connection.set("scm:git:git://github.com/ioki-mobility/kmp-passenger-api.git")
-                    developerConnection.set("scm:git:ssh://git@github.com/ioki-mobility/kmp-passenger-api.git")
-                }
+                connection.set("scm:git:git://github.com/ioki-mobility/kmp-passenger-api.git")
+                developerConnection.set("scm:git:ssh://git@github.com/ioki-mobility/kmp-passenger-api.git")
             }
         }
     }


### PR DESCRIPTION
fixes #36 

You can test it by running `publiToMavLo` task.
Open `~/.m2`.
In this branch no `library-android` dir is published anymore.
Instead a `passenger-api-android` exist.

AI summary:
This pull request includes changes to the `library/build.gradle.kts` file to address an issue with the Android target in the Maven publication process. The most important changes involve adding a workaround to ensure proper handling of the Android target.

Workaround for Android target:

* [`library/build.gradle.kts`](diffhunk://#diff-99c7344903488f04b710c22920f5f6fc7dfc61ac86e7bf6e7d932c603e3aad6dL79-R86): Added an `afterEvaluate` block to handle the `MavenPublication` type correctly for the Android target, ensuring the `artifactId` is replaced appropriately.

General cleanup:

* [`library/build.gradle.kts`](diffhunk://#diff-99c7344903488f04b710c22920f5f6fc7dfc61ac86e7bf6e7d932c603e3aad6dL113): Removed an unnecessary closing brace to maintain proper syntax.