### PR TITLE
Add javadoc to publication

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ kotlin = "2.0.21"
 nexus-publish = "2.0.0"
 kotlinx-serialization = "1.7.3"
 kotlinx-datetime = "0.6.1"
+dokka = "1.9.20"
 ktor = "3.0.0"
 ktlintVersion = "12.1.1"
 kotlinCoroutines = "1.9.0"
@@ -25,4 +26,5 @@ ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintVersion" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.ktlint)
+    alias(libs.plugins.dokka)
     `maven-publish`
     signing
 }
@@ -76,6 +77,12 @@ android {
     }
 }
 
+val dokkaJar = tasks.register<Jar>("dokkaJar") {
+    dependsOn(tasks.dokkaHtml)
+    from(tasks.dokkaHtml.flatMap { it.outputDirectory })
+    archiveClassifier.set("javadoc")
+}
+
 group = "com.ioki"
 version = "0.0.1-SNAPSHOT"
 
@@ -88,6 +95,7 @@ publishing {
         }
     }
     publications.withType<MavenPublication> {
+        artifact(dokkaJar)
         pom {
             name.set("KMP ioki Passenger API")
             description.set("Kotlin Multiplatform ioki Passenger API")


### PR DESCRIPTION
Adds a bit for #11 by preparing everything.
But actual no javadoc is written.

This is also required to publish the lib to maven central.

## How to test
Run `./gradlew publiToMavLoc` and inspect `~/.m2/com/ioki/passenger-api`.. Somewhere a new `-javadoc.jar` should be available. Replace `jar` with `zip`, unzip it and enjoy our nice javadoc 🙃 

![Screenshot 2024-10-31 at 1 32 48 PM](https://github.com/user-attachments/assets/52f9aa7f-f83d-4dee-82fc-84da91d7ed5d)
