### PR TITLE
Remove drtArea from ApiRideInquiryResponse

### DIFF
--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiRideInquiryResponse.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiRideInquiryResponse.kt
@@ -20,7 +20,6 @@ public data class ApiRideInquiryResponse(
     @Serializable
     public data class Constraints(
         val area: ApiArea?,
-        @SerialName(value = "drt_area") val drtArea: PassengerApiArea?,
         @SerialName(value = "max_passengers") val maxPassengers: Int?,
     )
 

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideInquiryResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideInquiryResponseTest.kt
@@ -14,24 +14,6 @@ internal class ApiRideInquiryResponseTest : IokiApiModelTest() {
                 ),
                 constraints = ApiRideInquiryResponse.Constraints(
                     area = ApiArea("MultiPolygon", emptyList()),
-                    drtArea = PassengerApiArea(
-                        type = "",
-                        id = "",
-                        name = "",
-                        slug = "",
-                        areaType = "",
-                        color = "",
-                        opacity = 0.5f,
-                        strokeWeight = 1,
-                        fillColor = "",
-                        fillOpacity = 0.5f,
-                        invert = false,
-                        zIndex = 0,
-                        legendIndex = 0,
-                        legendTitle = null,
-                        legendDescription = null,
-                        area = ApiArea("", emptyList()),
-                    ),
                     maxPassengers = 1,
                 ),
                 errors = listOf("service_not_available"),
@@ -65,25 +47,6 @@ private val rideInquiryResponse =
     "area": {
       "type": "MultiPolygon",
       "coordinates": []
-    },
-    "drt_area": {
-      "type": "",
-      "id": "",
-      "name": "",
-      "slug": "",
-      "area_type": "",
-      "color": "",
-      "opacity": 0.5,
-      "stroke_weight": 1,
-      "fill_color": "",
-      "fill_opacity": 0.5,
-      "invert": false,
-      "z_index": 0,
-      "legend_index": 0,
-      "area": {
-        "type": "",
-        "coordinates": []
-      }
     }
   },
   "errors": [


### PR DESCRIPTION
Follow up to https://github.com/dbdrive/beiwagen-android/pull/7128
The RideInquiry api [here](https://developers.pages.io.ki/api_docs/refs/main/passenger-api.html#tag/Ride-Inquiry/paths/~1api~1passenger~1ride_inquiry/post) no longer uses drtArea, so we can remove it!