### PR TITLE
Fix `com.ioki.result.Result` configuration

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -27,12 +27,13 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(libs.result)
                 implementation(libs.kotlinx.serialization)
                 implementation(libs.ktor.core)
                 implementation(libs.ktor.serialization)
                 implementation(libs.ktor.client.negotiation)
+
                 api(libs.kotlinx.datetime)
+                api(libs.result)
             }
         }
         val commonTest by getting {


### PR DESCRIPTION
Its in a public API so it should be an API dependency 🤷 🙃 