### PR TITLE
Remove unsupported from doorState enum

### DIFF
--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiDoorStateChangeRequest.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiDoorStateChangeRequest.kt
@@ -1,42 +1,15 @@
 package com.ioki.passenger.api.models
 
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.descriptors.PrimitiveKind
-import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
 
 @Serializable
 public data class ApiDoorStateChangeRequest(
     @SerialName(value = "desired_state") val desiredState: DesiredState,
 ) {
-    @Serializable(with = DesiredStateSerializer::class)
+    @Serializable
     public enum class DesiredState {
         @SerialName(value = "unlocked")
         UNLOCKED,
-        UNSUPPORTED,
-    }
-}
-
-internal object DesiredStateSerializer : KSerializer<ApiDoorStateChangeRequest.DesiredState> {
-    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("DesiredState", PrimitiveKind.STRING)
-
-    override fun serialize(encoder: Encoder, value: ApiDoorStateChangeRequest.DesiredState) {
-        encoder.encodeString(
-            when (value) {
-                ApiDoorStateChangeRequest.DesiredState.UNLOCKED -> "unlocked"
-                ApiDoorStateChangeRequest.DesiredState.UNSUPPORTED -> "unsupported"
-            },
-        )
-    }
-
-    override fun deserialize(decoder: Decoder): ApiDoorStateChangeRequest.DesiredState {
-        return when (decoder.decodeString()) {
-            "unlocked" -> ApiDoorStateChangeRequest.DesiredState.UNLOCKED
-            else -> ApiDoorStateChangeRequest.DesiredState.UNSUPPORTED
-        }
     }
 }

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiDoorStateChangeRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiDoorStateChangeRequestTest.kt
@@ -12,28 +12,11 @@ internal class ApiDoorStateChangeRequestTest : IokiApiModelTest() {
             doorStateChangeRequest,
         )
     }
-
-    @Test
-    fun serializationMinimal() {
-        testSerializationWithJsonString(
-            ApiDoorStateChangeRequest(
-                desiredState = ApiDoorStateChangeRequest.DesiredState.UNSUPPORTED,
-            ),
-            doorStateChangeRequestMinimal,
-        )
-    }
 }
 
 private val doorStateChangeRequest =
     """
 {
   "desired_state": "unlocked"
-}
-"""
-
-private val doorStateChangeRequestMinimal =
-    """
-{
-  "desired_state": "unsupported"
 }
 """


### PR DESCRIPTION
Given that
1. This is a request (and not a response)
2. And [this nice write up](https://github.com/ioki-mobility/kmp-passenger-api/issues/80#issuecomment-2596225169) from @vhontar 

we don't need a unsupported and therefore an custom Serializer for this enum.