### PR TITLE
Fix `AnyValue` serialization

### DIFF
--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/AnyValue.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/AnyValue.kt
@@ -36,10 +36,10 @@ internal object ValueSerializer : KSerializer<AnyValue> {
 
     override fun serialize(encoder: Encoder, value: AnyValue) {
         when (value) {
-            is AnyValue.StringValue -> encoder.encodeSerializableValue(AnyValue.StringValue.serializer(), value)
-            is AnyValue.IntValue -> encoder.encodeSerializableValue(AnyValue.IntValue.serializer(), value)
-            is AnyValue.BooleanValue -> encoder.encodeSerializableValue(AnyValue.BooleanValue.serializer(), value)
-            is AnyValue.DoubleValue -> encoder.encodeSerializableValue(AnyValue.DoubleValue.serializer(), value)
+            is AnyValue.StringValue -> encoder.encodeString(value.value)
+            is AnyValue.IntValue -> encoder.encodeInt(value.value)
+            is AnyValue.BooleanValue -> encoder.encodeBoolean(value.value)
+            is AnyValue.DoubleValue -> encoder.encodeDouble(value.value)
             // Handle other types as needed
         }
     }

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/AnyValue.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/AnyValue.kt
@@ -16,7 +16,7 @@ import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.intOrNull
 
-@Serializable(with = ValueSerializer::class)
+@Serializable(with = AnyValueSerializer::class)
 public sealed class AnyValue {
     @Serializable
     public data class StringValue(val value: String) : AnyValue()
@@ -31,8 +31,8 @@ public sealed class AnyValue {
     public data class DoubleValue(val value: Double) : AnyValue()
 }
 
-internal object ValueSerializer : KSerializer<AnyValue> {
-    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Value")
+internal object AnyValueSerializer : KSerializer<AnyValue> {
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("AnyValue")
 
     override fun serialize(encoder: Encoder, value: AnyValue) {
         when (value) {

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiAuthenticatedUserResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiAuthenticatedUserResponseTest.kt
@@ -11,8 +11,8 @@ internal class ApiAuthenticatedUserResponseTest : IokiApiModelTest() {
             receipt = true,
             confirmed = true,
         )
-        testSerializationWithJsonString(
-            model = ApiAuthenticatedUserResponse(
+        testJsonStringCanBeConvertedToModel(
+            expectedModel = ApiAuthenticatedUserResponse(
                 id = "abc123",
                 firstName = "John",
                 lastName = "Doe",

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiBodyTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiBodyTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiBodyTest : IokiApiModelTest() {
     @Test
     fun serializationString() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiBody("foobar"),
             apiBodyString,
         )
@@ -13,7 +13,7 @@ internal class ApiBodyTest : IokiApiModelTest() {
 
     @Test
     fun serializationMetaData() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiBody("foobar", ApiBody.Meta(1, true)),
             apiBodyMeta,
         )
@@ -21,7 +21,7 @@ internal class ApiBodyTest : IokiApiModelTest() {
 
     @Test
     fun serializationList() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiBody(listOf("foo", "bar")),
             apiBodyList,
         )
@@ -29,7 +29,7 @@ internal class ApiBodyTest : IokiApiModelTest() {
 
     @Test
     fun serializationNestedLists() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiBody(listOf(listOf("foo", "bar"), listOf("biz", "baz"))),
             apiBodyNestedList,
         )

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiBookingRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiBookingRequestTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiBookingRequestTest : IokiApiModelTest() {
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiBookingRequest(
                 rideVersion = 2,
                 solutionId = null,
@@ -18,7 +18,7 @@ internal class ApiBookingRequestTest : IokiApiModelTest() {
 
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiBookingRequest(
                 rideVersion = 2,
                 solutionId = "solutionId",

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiBookingStateTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiBookingStateTest.kt
@@ -17,7 +17,7 @@ internal class ApiBookingStateTest {
             data().forEach {
                 val bookingState = it[0] as ApiBookingState
                 val json = it[1] as String
-                testSerializationWithJsonString(bookingState, json)
+                testJsonStringCanBeConvertedToModel(bookingState, json)
             }
         }
 

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiBookingTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiBookingTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiBookingTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiBooking("ABC123"),
             bookingResponse,
         )

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiBootstrapResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiBootstrapResponseTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.Test
 internal class ApiBootstrapResponseTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiBootstrapResponse(
                 provider = createApiProvider(
                     name = "Some Company Inc.",

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiCancellationReasonTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiCancellationReasonTest.kt
@@ -19,7 +19,7 @@ internal class ApiCancellationReasonTest {
             data().forEach {
                 val reason = it[0] as ApiCancellationReason
                 val json = it[1] as String
-                testSerializationWithJsonString(reason, json)
+                testJsonStringCanBeConvertedToModel(reason, json)
             }
         }
 

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiCancellationRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiCancellationRequestTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiCancellationRequestTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiCancellationRequest(2, "Code", "statement_id"),
             cancellation,
         )
@@ -13,7 +13,7 @@ internal class ApiCancellationRequestTest : IokiApiModelTest() {
 
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiCancellationRequest(2, null, null),
             minimalCancellation,
         )

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiClientInfoResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiClientInfoResponseTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiClientInfoResponseTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiClientInfoResponse(
                 distributionUrl = "https://play.google.com/our-app",
                 termsOfServiceUrl = "https://example.com/terms_of_service.html",
@@ -23,7 +23,7 @@ internal class ApiClientInfoResponseTest : IokiApiModelTest() {
 
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiClientInfoResponse(
                 distributionUrl = "https://play.google.com/our-app",
                 termsOfServiceUrl = "https://example.com/terms_of_service.html",

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiCreateTipRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiCreateTipRequestTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.Test
 internal class ApiCreateTipRequestTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiCreateTipRequest(
                 amount = 150,
                 paymentMethod = createApiPaymentMethodRequest(ApiPaymentMethodType.SERVICE_CREDITS),

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiDeviceRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiDeviceRequestTest.kt
@@ -5,8 +5,8 @@ import kotlin.test.Test
 internal class ApiDeviceRequestTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
-            model = ApiDeviceRequest(token = "abc123"),
+        testJsonStringCanBeConvertedToModel(
+            expectedModel = ApiDeviceRequest(token = "abc123"),
             jsonString = deviceRequest,
         )
     }

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiDeviceResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiDeviceResponseTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiDeviceResponseTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiDeviceResponse(
                 id = "dev_857dd1b4-8a06-4a8e-8b2c-c123c4293283",
                 token = "abc123",

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiDoorStateChangeRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiDoorStateChangeRequestTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiDoorStateChangeRequestTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiDoorStateChangeRequest(
                 desiredState = ApiDoorStateChangeRequest.DesiredState.UNLOCKED,
             ),

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiDriverTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiDriverTest.kt
@@ -14,12 +14,12 @@ internal class ApiDriverTest : IokiApiModelTest() {
 
     @Test
     fun serialization() {
-        testSerializationWithJsonString(driver, driverJson)
+        testJsonStringCanBeConvertedToModel(driver, driverJson)
     }
 
     @Test
     fun serializationNoName() {
-        testSerializationWithJsonString(noNameDriver, noNameDriverJson)
+        testJsonStringCanBeConvertedToModel(noNameDriver, noNameDriverJson)
     }
 }
 

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiErrorBodyTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiErrorBodyTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiErrorBodyTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiErrorBody(
                 listOf(
                     ApiErrorBody.ApiError(
@@ -24,7 +24,7 @@ internal class ApiErrorBodyTest : IokiApiModelTest() {
 
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiErrorBody(),
             errorBodyMinimal,
         )

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiFareResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiFareResponseTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiFareResponseTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiFareResponse(
                 id = "far_123",
                 version = 0,
@@ -20,7 +20,7 @@ internal class ApiFareResponseTest : IokiApiModelTest() {
 
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiFareResponse(
                 id = "far_123",
                 version = 0,

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiFirebaseDebugRecordRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiFirebaseDebugRecordRequestTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiFirebaseDebugRecordRequestTest : IokiApiModelTest() {
     @Test
     fun serialization_RidePayload() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiFirebaseDebugRecordRequest(
                 path = "user/<user_id>/rides/<ride_id>",
                 payload = ApiFirebaseDebugRecordRequest.Payload.RidePayload(
@@ -20,7 +20,7 @@ internal class ApiFirebaseDebugRecordRequestTest : IokiApiModelTest() {
 
     @Test
     fun serialization_VehiclePayload() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiFirebaseDebugRecordRequest(
                 path = "user/<user_id>/rides/<ride_id>",
                 payload = ApiFirebaseDebugRecordRequest.Payload.VehiclePositionPayload(

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiFirebaseTokenResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiFirebaseTokenResponseTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiFirebaseTokenResponseTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiFirebaseTokenResponse("jwt", "encryptionKey"),
             firebaseToken,
         )

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiLocationTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiLocationTest.kt
@@ -8,8 +8,8 @@ import kotlin.test.expect
 internal class ApiLocationTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
-            model = ApiLocation(
+        testJsonStringCanBeConvertedToModel(
+            expectedModel = ApiLocation(
                 lat = 50.104558,
                 lng = 8.649113,
                 locationName = "DB Office Center",
@@ -37,7 +37,7 @@ internal class ApiLocationTest : IokiApiModelTest() {
 
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             createApiLocation(
                 lat = 50.104558,
                 lng = 8.649113,

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiLogPayAccountRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiLogPayAccountRequestTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiLogPayAccountRequestTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiLogPayAccountRequest(
                 emailAddress = "john.doe@gmail.com",
                 person = ApiLogPayAccountRequest.Person(
@@ -29,7 +29,7 @@ internal class ApiLogPayAccountRequestTest : IokiApiModelTest() {
 
     @Test
     fun serializationPaymentMethodTypeUndefined() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiLogPayAccountRequest(
                 emailAddress = "john.doe@gmail.com",
                 person = ApiLogPayAccountRequest.Person(
@@ -53,7 +53,7 @@ internal class ApiLogPayAccountRequestTest : IokiApiModelTest() {
 
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiLogPayAccountRequest(
                 emailAddress = "john.doe@gmail.com",
                 person = ApiLogPayAccountRequest.Person(

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiMoneyTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiMoneyTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiMoneyTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiMoney(
                 amount = 100,
                 currency = "EUR",

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiNotificationChannelTypeTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiNotificationChannelTypeTest.kt
@@ -17,7 +17,7 @@ internal class ApiNotificationChannelTypeTest {
             data().forEach {
                 val type = it[0] as ApiNotificationChannelType
                 val json = it[1] as String
-                testSerializationWithJsonString(type, json)
+                testJsonStringCanBeConvertedToModel(type, json)
             }
         }
 

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiOfferedCreditPackageTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiOfferedCreditPackageTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiOfferedCreditPackageTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiOfferedCreditPackage(
                 ApiMoney(amount = 200, currency = "EUR"),
                 ApiMoney(amount = 300, currency = "EUR"),

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPassengerSelectionRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPassengerSelectionRequestTest.kt
@@ -8,29 +8,28 @@ internal class ApiPassengerSelectionRequestTest : IokiApiModelTest() {
         testSerializationWithJsonString(
             ApiPassengerSelectionRequest(
                 type = "adult",
-                options =
-                    listOf(
-                        ApiOption(
-                            slug = "wheelchair",
-                            value = AnyValue.BooleanValue(false),
-                        ),
-                        ApiOption(
-                            slug = "bahncard",
-                            value = AnyValue.BooleanValue(false),
-                        ),
-                        ApiOption(
-                            slug = "walker",
-                            value = AnyValue.BooleanValue(true),
-                        ),
-                        ApiOption(
-                            slug = "public_transport_ticket",
-                            value = AnyValue.BooleanValue(true),
-                        ),
-                        ApiOption(
-                            slug = "blue_badge",
-                            value = AnyValue.BooleanValue(false),
-                        ),
+                options = listOf(
+                    ApiOption(
+                        slug = "wheelchair",
+                        value = AnyValue.BooleanValue(false),
                     ),
+                    ApiOption(
+                        slug = "bahncard",
+                        value = AnyValue.BooleanValue(false),
+                    ),
+                    ApiOption(
+                        slug = "walker",
+                        value = AnyValue.BooleanValue(true),
+                    ),
+                    ApiOption(
+                        slug = "public_transport_ticket",
+                        value = AnyValue.BooleanValue(true),
+                    ),
+                    ApiOption(
+                        slug = "blue_badge",
+                        value = AnyValue.BooleanValue(false),
+                    ),
+                ),
                 firstName = "Spider",
                 lastName = "Man",
             ),

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPassengerSelectionRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPassengerSelectionRequestTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiPassengerSelectionRequestTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiPassengerSelectionRequest(
                 type = "adult",
                 options = listOf(
@@ -39,7 +39,7 @@ internal class ApiPassengerSelectionRequestTest : IokiApiModelTest() {
 
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiPassengerSelectionRequest(
                 type = "child",
                 options = listOf(
@@ -73,7 +73,7 @@ internal class ApiPassengerSelectionRequestTest : IokiApiModelTest() {
 
     @Test
     fun deserializationMinimal() {
-        testDeserializationWithJsonString(
+        testModelCanBeConvertedToJsonString(
             passengerSelectionRequestMinimal,
             ApiPassengerSelectionRequest(
                 type = "child",

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPassengerSelectionRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPassengerSelectionRequestTest.kt
@@ -9,28 +9,28 @@ internal class ApiPassengerSelectionRequestTest : IokiApiModelTest() {
             ApiPassengerSelectionRequest(
                 type = "adult",
                 options =
-                listOf(
-                    ApiOption(
-                        slug = "wheelchair",
-                        value = AnyValue.BooleanValue(false),
+                    listOf(
+                        ApiOption(
+                            slug = "wheelchair",
+                            value = AnyValue.BooleanValue(false),
+                        ),
+                        ApiOption(
+                            slug = "bahncard",
+                            value = AnyValue.BooleanValue(false),
+                        ),
+                        ApiOption(
+                            slug = "walker",
+                            value = AnyValue.BooleanValue(true),
+                        ),
+                        ApiOption(
+                            slug = "public_transport_ticket",
+                            value = AnyValue.BooleanValue(true),
+                        ),
+                        ApiOption(
+                            slug = "blue_badge",
+                            value = AnyValue.BooleanValue(false),
+                        ),
                     ),
-                    ApiOption(
-                        slug = "bahncard",
-                        value = AnyValue.BooleanValue(false),
-                    ),
-                    ApiOption(
-                        slug = "walker",
-                        value = AnyValue.BooleanValue(true),
-                    ),
-                    ApiOption(
-                        slug = "public_transport_ticket",
-                        value = AnyValue.BooleanValue(true),
-                    ),
-                    ApiOption(
-                        slug = "blue_badge",
-                        value = AnyValue.BooleanValue(false),
-                    ),
-                ),
                 firstName = "Spider",
                 lastName = "Man",
             ),
@@ -69,6 +69,40 @@ internal class ApiPassengerSelectionRequestTest : IokiApiModelTest() {
                 lastName = null,
             ),
             passengerSelectionRequestMinimal,
+        )
+    }
+
+    @Test
+    fun deserializationMinimal() {
+        testDeserializationWithJsonString(
+            passengerSelectionRequestMinimal,
+            ApiPassengerSelectionRequest(
+                type = "child",
+                options = listOf(
+                    ApiOption(
+                        slug = "wheelchair",
+                        value = AnyValue.BooleanValue(false),
+                    ),
+                    ApiOption(
+                        slug = "bahncard",
+                        value = AnyValue.BooleanValue(false),
+                    ),
+                    ApiOption(
+                        slug = "walker",
+                        value = AnyValue.BooleanValue(true),
+                    ),
+                    ApiOption(
+                        slug = "public_transport_ticket",
+                        value = AnyValue.BooleanValue(true),
+                    ),
+                    ApiOption(
+                        slug = "blue_badge",
+                        value = AnyValue.BooleanValue(false),
+                    ),
+                ),
+                firstName = null,
+                lastName = null,
+            ),
         )
     }
 }

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPaymentMethodCreationRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPaymentMethodCreationRequestTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiPaymentMethodCreationRequestTest : IokiApiModelTest() {
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiPaymentMethodCreationRequest(
                 paymentMethodType = "stripe",
                 details = ApiPaymentMethodCreationRequest.Details(
@@ -20,7 +20,7 @@ internal class ApiPaymentMethodCreationRequestTest : IokiApiModelTest() {
 
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiPaymentMethodCreationRequest(
                 paymentMethodType = "stripe",
                 details = ApiPaymentMethodCreationRequest.Details(

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPaymentMethodResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPaymentMethodResponseTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiPaymentMethodResponseTest : IokiApiModelTest() {
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiPaymentMethodResponse(ApiPaymentMethodType.CASH, null, null),
             paymentMethodMinimal,
         )
@@ -13,8 +13,8 @@ internal class ApiPaymentMethodResponseTest : IokiApiModelTest() {
 
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
-            model = ApiPaymentMethodResponse(
+        testJsonStringCanBeConvertedToModel(
+            expectedModel = ApiPaymentMethodResponse(
                 paymentMethodType = ApiPaymentMethodType.STRIPE,
                 id = "someId",
                 summary = ApiPaymentMethodResponse.Summary(

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPaymentMethodResponseTypeTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPaymentMethodResponseTypeTest.kt
@@ -19,7 +19,7 @@ internal class ApiPaymentMethodResponseTypeTest {
             data().forEach {
                 val type = it[0] as ApiPaymentMethodType
                 val json = it[1] as String
-                testSerializationWithJsonString(type, json)
+                testJsonStringCanBeConvertedToModel(type, json)
             }
         }
 

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPaypalClientTokenResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPaypalClientTokenResponseTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiPaypalClientTokenResponseTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiPaypalClientTokenResponse("token"),
             paypalClientToken,
         )

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPersonalDiscountPurchaseRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPersonalDiscountPurchaseRequestTest.kt
@@ -6,8 +6,8 @@ import kotlin.test.Test
 internal class ApiPersonalDiscountPurchaseRequestTest : IokiApiModelTest() {
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
-            model = ApiPersonalDiscountPurchaseRequest(
+        testJsonStringCanBeConvertedToModel(
+            expectedModel = ApiPersonalDiscountPurchaseRequest(
                 personalDiscountTypeId = "id",
                 paymentMethod = createApiPaymentMethodRequest(ApiPaymentMethodType.SERVICE_CREDITS),
                 paypalSecureElement = null,
@@ -19,7 +19,7 @@ internal class ApiPersonalDiscountPurchaseRequestTest : IokiApiModelTest() {
 
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiPersonalDiscountPurchaseRequest(
                 personalDiscountTypeId = "id",
                 paymentMethod = createApiPaymentMethodRequest(ApiPaymentMethodType.SERVICE_CREDITS),

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPersonalDiscountResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPersonalDiscountResponseTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.Test
 internal class ApiPersonalDiscountResponseTest : IokiApiModelTest() {
     @Test
     fun `personal discount serialization validity usage`() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             stubPersonalDiscountCount,
             purchasedDiscountsUsageJson,
         )
@@ -14,7 +14,7 @@ internal class ApiPersonalDiscountResponseTest : IokiApiModelTest() {
 
     @Test
     fun `personal discount serialization validity time`() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             stubPersonalDiscountTime,
             purchasedDiscountsRelativeJson,
         )
@@ -22,7 +22,7 @@ internal class ApiPersonalDiscountResponseTest : IokiApiModelTest() {
 
     @Test
     fun `personal discount serialization validity usage usage AND time`() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             stubPersonalDiscountTimeAndCount,
             purchasedDiscountsUsageAndTimeJson,
         )

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPersonalDiscountTypeResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPersonalDiscountTypeResponseTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.Test
 internal class ApiPersonalDiscountTypeResponseTest : IokiApiModelTest() {
     @Test
     fun `personal discount serialization absolute`() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             stubPersonalDiscountTypeCount,
             purchaseablePersonalDiscountTypeAbsoluteJson,
         )
@@ -14,7 +14,7 @@ internal class ApiPersonalDiscountTypeResponseTest : IokiApiModelTest() {
 
     @Test
     fun `personal discount serialization relative`() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             stubPersonalDiscountTypeTime,
             purchaseablePersonalDiscountTypeRelativeJson,
         )
@@ -22,7 +22,7 @@ internal class ApiPersonalDiscountTypeResponseTest : IokiApiModelTest() {
 
     @Test
     fun `personal discount serialization absolute AND relative`() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             stubPersonalDiscountTypeTimeAndCount,
             purchaseablePersonalDiscountTypeAbsoluteRelativeJson,
         )
@@ -30,7 +30,7 @@ internal class ApiPersonalDiscountTypeResponseTest : IokiApiModelTest() {
 
     @Test
     fun `personal discount type serialization with LocalDate`() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             stubPersonalDiscountTypeLocalDate,
             purchaseablePersonalDiscountTypeLocalDateJson,
         )

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPhoneVerificationRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPhoneVerificationRequestTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiPhoneVerificationRequestTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiPhoneVerificationRequest("+491601234567", null),
             verification,
         )

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiProductTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiProductTest.kt
@@ -8,8 +8,8 @@ import kotlin.test.Test
 internal class ApiProductTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
-            model = ApiProduct(
+        testJsonStringCanBeConvertedToModel(
+            expectedModel = ApiProduct(
                 id = "abc-123",
                 version = 1,
                 name = "Magic Bus Frankfurt",
@@ -193,8 +193,8 @@ internal class ApiProductTest : IokiApiModelTest() {
 
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
-            model =
+        testJsonStringCanBeConvertedToModel(
+            expectedModel =
             ApiProduct(
                 id = "abc-123",
                 version = 1,

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiProviderNotificationSettingsResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiProviderNotificationSettingsResponseTest.kt
@@ -5,8 +5,8 @@ import kotlin.test.Test
 internal class ApiProviderNotificationSettingsResponseTest : IokiApiModelTest() {
     @Test
     fun serializationNoChannels() {
-        testSerializationWithJsonString(
-            model = ApiProviderNotificationSettingsResponse(
+        testJsonStringCanBeConvertedToModel(
+            expectedModel = ApiProviderNotificationSettingsResponse(
                 id = "ride_notifications",
                 type = "notification_settings",
                 name = "ride_notifications",
@@ -18,8 +18,8 @@ internal class ApiProviderNotificationSettingsResponseTest : IokiApiModelTest() 
 
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
-            model = ApiProviderNotificationSettingsResponse(
+        testJsonStringCanBeConvertedToModel(
+            expectedModel = ApiProviderNotificationSettingsResponse(
                 id = "ride_notifications",
                 type = "notification_settings",
                 name = "ride_notifications",

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiProviderTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiProviderTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.Test
 internal class ApiProviderTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiProvider(
                 name = "Ioki GmbH",
                 paymentServiceProvider = ApiProvider.PaymentServiceProvider.STRIPE,
@@ -49,7 +49,7 @@ internal class ApiProviderTest : IokiApiModelTest() {
 
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             createApiProvider(name = "Ioki GmbH", features = ApiProvider.Features.NONE),
             providerMinimal,
         )
@@ -57,7 +57,7 @@ internal class ApiProviderTest : IokiApiModelTest() {
 
     @Test
     fun serializationStipeTypeWithWrongTypeMinimal() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             createApiProvider(
                 name = "Ioki GmbH",
                 features = ApiProvider.Features.NONE,

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPurchasedCreditPackageResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPurchasedCreditPackageResponseTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiPurchasedCreditPackageResponseTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiPurchasedCreditPackageResponse(balance = ApiMoney(800, "EUR")),
             purchasedCreditPackage,
         )

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPurchasingCreditPackageRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPurchasingCreditPackageRequestTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiPurchasingCreditPackageRequestTest : IokiApiModelTest() {
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiPurchasingCreditPackageRequest(
                 cost = 800,
                 value = 1000,
@@ -22,7 +22,7 @@ internal class ApiPurchasingCreditPackageRequestTest : IokiApiModelTest() {
 
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiPurchasingCreditPackageRequest(
                 cost = 800,
                 value = 1000,

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRatingRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRatingRequestTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiRatingRequestTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiRatingRequest(
                 rideVersion = 2,
                 rideRating = 1,
@@ -23,7 +23,7 @@ internal class ApiRatingRequestTest : IokiApiModelTest() {
 
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiRatingRequest(
                 rideVersion = 2,
                 rideRating = null,

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRatingResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRatingResponseTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiRatingResponseTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiRatingResponse(
                 id = "abc123",
                 rideRating = 1,
@@ -21,7 +21,7 @@ internal class ApiRatingResponseTest : IokiApiModelTest() {
 
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiRatingResponse(
                 id = "abc123",
                 rideRating = null,

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRedeemPromoCodeRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRedeemPromoCodeRequestTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiRedeemPromoCodeRequestTest : IokiApiModelTest() {
     @Test
     fun `serialization of promo type`() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiRedeemPromoCodeRequest("summer_special"),
             redeemPromoCodeRequest,
         )
@@ -13,7 +13,7 @@ internal class ApiRedeemPromoCodeRequestTest : IokiApiModelTest() {
 
     @Test
     fun `serialization of service credit type`() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiRedeemPromoCodeRequest("summer_special"),
             redeemPromoCodeCreditRequest,
         )

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRedeemedPromoCodeResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRedeemedPromoCodeResponseTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.Test
 internal class ApiRedeemedPromoCodeResponseTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiRedeemedPromoCodeResponse(
                 id = "abc123",
                 createdAt = Instant.parse("1970-01-01T00:00:00Z"),
@@ -20,7 +20,7 @@ internal class ApiRedeemedPromoCodeResponseTest : IokiApiModelTest() {
 
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiRedeemedPromoCodeResponse(
                 id = "abc123",
                 createdAt = Instant.parse("1970-01-01T00:00:00Z"),

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRequestTokenRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRequestTokenRequestTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiRequestTokenRequestTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiRequestTokenRequest("+491601234567", "123456"),
             requestTokenRequest,
         )

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRequestTokenResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRequestTokenResponseTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiRequestTokenResponseTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiRequestTokenResponse(
                 id = "tok_6b083e2b-5c5b-4a58-b3a1-46442928989c",
                 type = "request_token",

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideInquiryRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideInquiryRequestTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.Test
 internal class ApiRideInquiryRequestTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiRideInquiryRequest(
                 productId = "prd_123",
                 origin = ApiRideInquiryRequest.Location(
@@ -98,7 +98,7 @@ internal class ApiRideInquiryRequestTest : IokiApiModelTest() {
 
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiRideInquiryRequest(
                 productId = "prd_123",
                 origin = ApiRideInquiryRequest.Location(

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideInquiryResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideInquiryResponseTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.Test
 internal class ApiRideInquiryResponseTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiRideInquiryResponse(
                 availability = ApiRideInquiryResponse.Availability(
                     available = true,

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideRequestTest.kt
@@ -6,8 +6,8 @@ import kotlin.test.Test
 internal class ApiRideRequestTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
-            model = ApiRideRequest(
+        testJsonStringCanBeConvertedToModel(
+            expectedModel = ApiRideRequest(
                 productId = "abc-123",
                 passengers = listOf(
                     ApiPassengerSelectionRequest(

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideResponseTest.kt
@@ -9,8 +9,8 @@ import kotlin.test.Test
 internal class ApiRideResponseTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
-            model = ApiRideResponse(
+        testJsonStringCanBeConvertedToModel(
+            expectedModel = ApiRideResponse(
                 id = "rid_c7394eb7-2af1-4d0c-9e8e-56c2c69f0495",
                 productId = "product-id",
                 state = ApiBookingState.SEARCHING,
@@ -231,8 +231,8 @@ internal class ApiRideResponseTest : IokiApiModelTest() {
 
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
-            model = ApiRideResponse(
+        testJsonStringCanBeConvertedToModel(
+            expectedModel = ApiRideResponse(
                 id = "rid_c7394eb7-2af1-4d0c-9e8e-56c2c69f0495",
                 productId = "product-id",
                 state = ApiBookingState.SEARCHING,

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideSeriesRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideSeriesRequestTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.Test
 internal class ApiRideSeriesRequestTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiRideSeriesRequest(
                 additionalDates = listOf(
                     LocalDate.parse("2019-06-18"),

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideSeriesResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideSeriesResponseTest.kt
@@ -8,7 +8,7 @@ import kotlin.test.Test
 internal class ApiRideSeriesResponseTest : IokiApiModelTest() {
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiRideSeriesResponse(
                 id = "ris_d3cf174f-7fc3-49fa-9403-f9ba4b9aa9ce",
                 createdAt = null,
@@ -25,7 +25,7 @@ internal class ApiRideSeriesResponseTest : IokiApiModelTest() {
 
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiRideSeriesResponse(
                 "ris_d3cf174f-7fc3-49fa-9403-f9ba4b9aa9ce",
                 Instant.parse("2019-05-15T12:23:41Z"),

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiSignUpRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiSignUpRequestTest.kt
@@ -11,7 +11,7 @@ internal class ApiSignUpRequestTest : IokiApiModelTest() {
             receipt = true,
             confirmed = null,
         )
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiSignUpRequest(
                 firstName = "John",
                 lastName = "Doe",

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiStationsRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiStationsRequestTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiStationsRequestTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiStationsRequest(
                 productId = "id",
                 query = "query",
@@ -20,7 +20,7 @@ internal class ApiStationsRequestTest : IokiApiModelTest() {
 
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiStationsRequest("id", ""),
             stationsRequestMinimal,
         )

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiStripeSetupIntentResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiStripeSetupIntentResponseTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiStripeSetupIntentResponseTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiStripeSetupIntentResponse("secret"),
             stripeSetupIntent,
         )

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiStripeTypeTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiStripeTypeTest.kt
@@ -17,7 +17,7 @@ internal class ApiStripeTypeTest {
             data().forEach {
                 val type = it[0] as ApiStripeType
                 val json = it[1] as String
-                testSerializationWithJsonString(type, json)
+                testJsonStringCanBeConvertedToModel(type, json)
             }
         }
 

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiTicketingShopConfigurationResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiTicketingShopConfigurationResponseTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiTicketingShopConfigurationResponseTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiTicketingShopConfigurationResponse(
                 purchaseOptions = listOf(
                     ApiTicketingProductOption(

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiTipResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiTipResponseTest.kt
@@ -5,8 +5,8 @@ import kotlin.test.Test
 internal class ApiTipResponseTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
-            model = ApiTipResponse(
+        testJsonStringCanBeConvertedToModel(
+            expectedModel = ApiTipResponse(
                 ApiMoney(
                     amount = 150,
                     currency = "EUR",

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiTippingResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiTippingResponseTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiTippingResponseTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             tipping,
             tippingJson,
         )
@@ -13,7 +13,7 @@ internal class ApiTippingResponseTest : IokiApiModelTest() {
 
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             tippingMinimal,
             tippingMinimalJson,
         )

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiUpdateUserNotificationSettingsRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiUpdateUserNotificationSettingsRequestTest.kt
@@ -5,8 +5,8 @@ import kotlin.test.Test
 internal class ApiUpdateUserNotificationSettingsRequestTest : IokiApiModelTest() {
     @Test
     fun serializationNoChannels() {
-        testSerializationWithJsonString(
-            model = ApiUpdateUserNotificationSettingsRequest(
+        testJsonStringCanBeConvertedToModel(
+            expectedModel = ApiUpdateUserNotificationSettingsRequest(
                 name = "ride_notifications",
                 channels = emptyList(),
             ),
@@ -16,8 +16,8 @@ internal class ApiUpdateUserNotificationSettingsRequestTest : IokiApiModelTest()
 
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
-            model = ApiUpdateUserNotificationSettingsRequest(
+        testJsonStringCanBeConvertedToModel(
+            expectedModel = ApiUpdateUserNotificationSettingsRequest(
                 name = "ride_notifications",
                 channels = listOf(ApiNotificationChannelType.SMS),
             ),

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiUpdateUserRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiUpdateUserRequestTest.kt
@@ -11,7 +11,7 @@ internal class ApiUpdateUserRequestTest : IokiApiModelTest() {
             receipt = true,
             confirmed = null,
         )
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiUpdateUserRequest(
                 version = 2,
                 firstName = "John",
@@ -30,7 +30,7 @@ internal class ApiUpdateUserRequestTest : IokiApiModelTest() {
 
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiUpdateUserRequest(2, null, null, null, null, null, null),
             updateUserRequestMinimal,
         )

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiUserFlagsRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiUserFlagsRequestTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiUserFlagsRequestTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiUserFlagsRequest(
                 version = 0,
                 termsAccepted = true,
@@ -18,7 +18,7 @@ internal class ApiUserFlagsRequestTest : IokiApiModelTest() {
 
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiUserFlagsRequest(
                 version = 0,
                 termsAccepted = true,

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiUserNotificationSettingsResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiUserNotificationSettingsResponseTest.kt
@@ -5,8 +5,8 @@ import kotlin.test.Test
 internal class ApiUserNotificationSettingsResponseTest : IokiApiModelTest() {
     @Test
     fun serializationNoChannels() {
-        testSerializationWithJsonString(
-            model = ApiUserNotificationSettingsResponse(
+        testJsonStringCanBeConvertedToModel(
+            expectedModel = ApiUserNotificationSettingsResponse(
                 id = "ride_notifications",
                 type = "notification_settings",
                 name = "ride_notifications",
@@ -18,8 +18,8 @@ internal class ApiUserNotificationSettingsResponseTest : IokiApiModelTest() {
 
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
-            model = ApiUserNotificationSettingsResponse(
+        testJsonStringCanBeConvertedToModel(
+            expectedModel = ApiUserNotificationSettingsResponse(
                 id = "ride_notifications",
                 type = "notification_settings",
                 name = "ride_notifications",

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiVehiclePositionTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiVehiclePositionTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiVehiclePositionTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiVehiclePosition(lat = 49.012, lng = 8.245, heading = 123.0f),
             vehiclePosition,
         )

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiVehicleTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiVehicleTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 internal class ApiVehicleTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiVehicle(
                 licensePlate = "AB CD 123",
                 nickname = "Bob the Vehicle 2",
@@ -33,7 +33,7 @@ internal class ApiVehicleTest : IokiApiModelTest() {
 
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
+        testJsonStringCanBeConvertedToModel(
             ApiVehicle(
                 "AB CD 123",
                 "Bob the Vehicle 2",

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiVenueResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiVenueResponseTest.kt
@@ -5,8 +5,8 @@ import kotlin.test.Test
 internal class ApiVenueResponseTest : IokiApiModelTest() {
     @Test
     fun serialization() {
-        testSerializationWithJsonString(
-            model = ApiVenueResponse(
+        testJsonStringCanBeConvertedToModel(
+            expectedModel = ApiVenueResponse(
                 id = "venue-id",
                 city = "city",
                 county = "county",
@@ -27,8 +27,8 @@ internal class ApiVenueResponseTest : IokiApiModelTest() {
 
     @Test
     fun serializationMinimal() {
-        testSerializationWithJsonString(
-            model =
+        testJsonStringCanBeConvertedToModel(
+            expectedModel =
             ApiVenueResponse(
                 id = "venue-id",
                 city = "city",

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/IokiApiModelTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/IokiApiModelTest.kt
@@ -4,14 +4,14 @@ import com.ioki.passenger.api.internal.utils.createJson
 import kotlin.test.assertEquals
 
 internal abstract class IokiApiModelTest {
-    inline fun <reified T : Any> testSerializationWithJsonString(model: T, jsonString: String) {
+    inline fun <reified T : Any> testJsonStringCanBeConvertedToModel(expectedModel: T, jsonString: String) {
         val fromJson = createJson().decodeFromString<T>(jsonString)
-        assertEquals(expected = model, actual = fromJson)
+        assertEquals(expected = expectedModel, actual = fromJson)
     }
 
-    inline fun <reified T : Any> testDeserializationWithJsonString(jsonString: String, model: T) {
+    inline fun <reified T : Any> testModelCanBeConvertedToJsonString(expectedJsonString: String, model: T) {
         val json = createJson().encodeToString(model)
-        assertEquals(expected = jsonString.normalize, actual = json)
+        assertEquals(expected = expectedJsonString.normalize, actual = json)
     }
 
     private val String.normalize: String get() = replace("\\s+".toRegex(), "")

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/IokiApiModelTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/IokiApiModelTest.kt
@@ -1,11 +1,18 @@
 package com.ioki.passenger.api.models
 
 import com.ioki.passenger.api.internal.utils.createJson
-import kotlin.test.expect
+import kotlin.test.assertEquals
 
 internal abstract class IokiApiModelTest {
     inline fun <reified T : Any> testSerializationWithJsonString(model: T, jsonString: String) {
         val fromJson = createJson().decodeFromString<T>(jsonString)
-        expect(model) { fromJson }
+        assertEquals(expected = model, actual = fromJson)
     }
+
+    inline fun <reified T : Any> testDeserializationWithJsonString(jsonString: String, model: T) {
+        val json = createJson().encodeToString(model)
+        assertEquals(expected = jsonString.normalize, actual = json)
+    }
+
+    private val String.normalize: String get() = replace("\\s+".toRegex(), "")
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
![image](https://github.com/user-attachments/assets/0c0d61d7-189b-4df5-b50c-159e8716f89a)

This PR fixes this.
You can run the tests with the old `ValueSerializer` and it will fail 🙃 

Note to the `IokiApiModelTest` class.
Actually we are naming it wrong.
`testSerializationWithJsonString` -> We are doing `decode` here 
Decode is also known as deserialization:
![Screenshot 2025-02-13 at 3 22 50 PM](https://github.com/user-attachments/assets/1fa0de86-6419-4b5e-8b5a-a09f66e4e20d)

SO basically the functions are swapped 🫣 (Haven't we have been there already ? #93)

However, I decided to kept that wrong and just add the other weongly named function 😅 
Let me know if you think we should change that...

