### PR TITLE
Introduce ApiResult function factory

### DIFF
--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/result/Result.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/result/Result.kt
@@ -8,6 +8,8 @@ public typealias ApiResult<T> = Result<SuccessData<T>, Error>
 
 public data class SuccessData<out T>(val value: T, val meta: ApiBody.Meta? = null)
 
+public fun <T> ApiResult(value: T): ApiResult<T> = Result.Success(SuccessData(value))
+
 public val <T> Result.Success<SuccessData<T>>.value: T
     get() = this.data.value
 


### PR DESCRIPTION
## Description
We are using the [`com.ioki.result.Result`](https://github.com/ioki-mobility/Result) type in our code.
For convinience reasons, we wrapped it behind our own `ApiResult` typealias.
This works great so far.
However, especially in tests, it might get consued if a user has to fake a `ApiResult`.
Instead of constructing a `ApiResult` like he woudl expect `ApiResult(data)`, he has to know about the `Result` type.
Further, it needs to know about the `SuccessData` class we have in place.
```kotlin
// Works, but expose logic of `Result` and `SuccessData`
val a: ApiResult<ApiRideResponse> = Result.Success(SuccessData(createApiRideResponse()))
// Does not compile, because `SuccessData` is abstracted away. But this might be a common error
val b: ApiResult<ApiRideResponse> = Result.Success(createApiRideResponse())
```

With this, I introduce a factory function that is doing exactly the `a` case. 
But hidden behind a fake constructor:
```kotlin
// Both are the same and work perfectly fine
val a: ApiResult<ApiRideResponse> = Result.Success(SuccessData(createApiRideResponse()))
val b: ApiResult<ApiRideResponse> = ApiResult(createApiRideResponse())
```

The "problem", however, is that we don't distinct between `Success` and `Failure` here.
So a `Failure` case, still have to be constructed like this:
```kotlin
val c: ApiResult<ApiRideResponse> = Result.Failure(com.ioki.passenger.api.result.Error.Connectivity(Throwable()))
```
 
I haven't found a good solution to solve this yet.
One approach could be like this:
```kotlin
private fun <T : Any> ApiResult(value: Any): ApiResult<T> {
    return if (value is com.ioki.passenger.api.result.Error) {
        return Result.Failure(value)
    } else {
        Result.Success(SuccessData(value as T))
    }
}
```
But this only works if we define the type:
```kotlin
// Works
val a: ApiResult<ApiRideResponse> = ApiResult(createApiRideResponse())
val c: ApiResult<ApiRideResponse> = ApiResult(com.ioki.passenger.api.result.Error.Connectivity(Throwable()))

// Doesn't work // Not enough information to infer <T>
val x = ApiResult(com.ioki.passenger.api.result.Error.Connectivity(Throwable()))
val y = ApiResult(createApiRideResponse())
```

Maybe someone have an idea to make that work?! 🤔 🤷 

## Test artifact

**Test models updated?**

In case you created a new APIObject or extracted one,
make sure to update the test fakes in [`test/src/commonMain/models`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test/models) as well.

Changes to existing models will probably fail on testing and are noticed by the CI.

**Test services updated?**

In case you created a new service or extracted one,
make sure to update the test fakes in [`test/src/commonMain/services`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test) as well.

Changes to existing services will probably fail on testing and are noticed by the CI.
