### PR TITLE
Add operator_cancelled to ApiCancellationReason

### DIFF
--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiCancellationReason.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiCancellationReason.kt
@@ -1,7 +1,13 @@
 package com.ioki.passenger.api.models
 
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.nullable
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 @Serializable
 public enum class ApiCancellationReason {
@@ -59,4 +65,68 @@ public enum class ApiCancellationReason {
     @SerialName(value = "operator_cancelled")
     OPERATOR_CANCELLED,
     UNSUPPORTED,
+}
+
+internal object ApiCancellationReasonSerializer : KSerializer<ApiCancellationReason?> {
+    override val descriptor = String.serializer().descriptor
+
+    @OptIn(ExperimentalSerializationApi::class)
+    override fun serialize(encoder: Encoder, value: ApiCancellationReason?) {
+        if (value == null) {
+            encoder.encodeNull()
+            return
+        }
+
+        encoder.encodeString(
+            when (value) {
+                ApiCancellationReason.PASSENGER_CANCELLED -> "passenger_cancelled"
+                ApiCancellationReason.PASSENGER_CANCELLED_SEARCHING_RIDE -> "passenger_cancelled_searching_ride"
+                ApiCancellationReason.PASSENGER_CANCELLED_OFFERED_RIDE -> "passenger_cancelled_offered_ride"
+                ApiCancellationReason.PASSENGER_CANCELLED_WAITING_FOR_DRIVER -> "passenger_cancelled_waiting_for_driver"
+                ApiCancellationReason.PASSENGER_CANCELLED_AFTER_PICKUP -> "passenger_cancelled_after_pickup"
+                ApiCancellationReason.PASSENGER_CANCELLED_BOOKED_RIDE -> "passenger_cancelled_booked_ride"
+                ApiCancellationReason.DRIVER_CANCELLED -> "driver_cancelled"
+                ApiCancellationReason.DRIVER_REJECTED -> "driver_rejected"
+                ApiCancellationReason.NO_VEHICLE_AVAILABLE -> "no_vehicle_available"
+                ApiCancellationReason.PASSENGER_DID_NOT_ACCEPT_IN_TIME -> "passenger_did_not_accept_in_time"
+                ApiCancellationReason.DRIVER_DID_NOT_ACCEPT_IN_TIME -> "driver_did_not_accept_in_time"
+                ApiCancellationReason.RIDE_REQUEST_OUTDATED -> "ride_request_outdated"
+                ApiCancellationReason.TRANSACTIONAL_SAVE_FAILED -> "transactional_save_failed"
+                ApiCancellationReason.NO_STATIONS_FOUND -> "no_stations_found"
+                ApiCancellationReason.APPLY_FAILED -> "apply_failed"
+                ApiCancellationReason.NO_TASK_LIST_FOUND -> "no_task_list_found"
+                ApiCancellationReason.PROHIBIT_PARALLEL_FILTER -> "prohibit_parallel_filter"
+                ApiCancellationReason.OPERATOR_CANCELLED -> "operator_cancelled"
+                ApiCancellationReason.UNSUPPORTED -> "UNSUPPORTED"
+            },
+        )
+    }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    override fun deserialize(decoder: Decoder): ApiCancellationReason? {
+        val stringValue =
+            decoder.decodeNullableSerializableValue(String.serializer().nullable) ?: return null
+
+        return when (stringValue) {
+            "passenger_cancelled" -> ApiCancellationReason.PASSENGER_CANCELLED
+            "passenger_cancelled_searching_ride" -> ApiCancellationReason.PASSENGER_CANCELLED_SEARCHING_RIDE
+            "passenger_cancelled_offered_ride" -> ApiCancellationReason.PASSENGER_CANCELLED_OFFERED_RIDE
+            "passenger_cancelled_waiting_for_driver" -> ApiCancellationReason.PASSENGER_CANCELLED_WAITING_FOR_DRIVER
+            "passenger_cancelled_after_pickup" -> ApiCancellationReason.PASSENGER_CANCELLED_AFTER_PICKUP
+            "passenger_cancelled_booked_ride" -> ApiCancellationReason.PASSENGER_CANCELLED_BOOKED_RIDE
+            "driver_cancelled" -> ApiCancellationReason.DRIVER_CANCELLED
+            "driver_rejected" -> ApiCancellationReason.DRIVER_REJECTED
+            "no_vehicle_available" -> ApiCancellationReason.NO_VEHICLE_AVAILABLE
+            "passenger_did_not_accept_in_time" -> ApiCancellationReason.PASSENGER_DID_NOT_ACCEPT_IN_TIME
+            "driver_did_not_accept_in_time" -> ApiCancellationReason.DRIVER_DID_NOT_ACCEPT_IN_TIME
+            "ride_request_outdated" -> ApiCancellationReason.RIDE_REQUEST_OUTDATED
+            "transactional_save_failed" -> ApiCancellationReason.TRANSACTIONAL_SAVE_FAILED
+            "no_stations_found" -> ApiCancellationReason.NO_STATIONS_FOUND
+            "apply_failed" -> ApiCancellationReason.APPLY_FAILED
+            "no_task_list_found" -> ApiCancellationReason.NO_TASK_LIST_FOUND
+            "prohibit_parallel_filter" -> ApiCancellationReason.PROHIBIT_PARALLEL_FILTER
+            "operator_cancelled" -> ApiCancellationReason.OPERATOR_CANCELLED
+            else -> ApiCancellationReason.UNSUPPORTED
+        }
+    }
 }

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiCancellationReason.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiCancellationReason.kt
@@ -55,5 +55,8 @@ public enum class ApiCancellationReason {
 
     @SerialName(value = "prohibit_parallel_filter")
     PROHIBIT_PARALLEL_FILTER,
+
+    @SerialName(value = "operator_cancelled")
+    OPERATOR_CANCELLED,
     UNSUPPORTED,
 }

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiRideResponse.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiRideResponse.kt
@@ -154,6 +154,7 @@ private object ApiCancellationReasonSerializer : KSerializer<ApiCancellationReas
                 ApiCancellationReason.APPLY_FAILED -> "apply_failed"
                 ApiCancellationReason.NO_TASK_LIST_FOUND -> "no_task_list_found"
                 ApiCancellationReason.PROHIBIT_PARALLEL_FILTER -> "prohibit_parallel_filter"
+                ApiCancellationReason.OPERATOR_CANCELLED -> "operator_cancelled"
                 ApiCancellationReason.UNSUPPORTED -> "UNSUPPORTED"
             },
         )
@@ -182,6 +183,7 @@ private object ApiCancellationReasonSerializer : KSerializer<ApiCancellationReas
             "apply_failed" -> ApiCancellationReason.APPLY_FAILED
             "no_task_list_found" -> ApiCancellationReason.NO_TASK_LIST_FOUND
             "prohibit_parallel_filter" -> ApiCancellationReason.PROHIBIT_PARALLEL_FILTER
+            "operator_cancelled" -> ApiCancellationReason.OPERATOR_CANCELLED
             else -> ApiCancellationReason.UNSUPPORTED
         }
     }

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiRideResponse.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiRideResponse.kt
@@ -1,14 +1,8 @@
 package com.ioki.passenger.api.models
 
 import kotlinx.datetime.Instant
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.builtins.nullable
-import kotlinx.serialization.builtins.serializer
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
 
 @Serializable
 public data class ApiRideResponse(
@@ -124,67 +118,3 @@ public val ApiRideResponse.hasDifferentDropoffAndDestinationPoints: Boolean
     get() = dropoff.hasDifferentPoint
 
 public typealias ApiBookedSolution = ApiOfferedSolution
-
-private object ApiCancellationReasonSerializer : KSerializer<ApiCancellationReason?> {
-    override val descriptor = String.serializer().descriptor
-
-    @OptIn(ExperimentalSerializationApi::class)
-    override fun serialize(encoder: Encoder, value: ApiCancellationReason?) {
-        if (value == null) {
-            encoder.encodeNull()
-            return
-        }
-
-        encoder.encodeString(
-            when (value) {
-                ApiCancellationReason.PASSENGER_CANCELLED -> "passenger_cancelled"
-                ApiCancellationReason.PASSENGER_CANCELLED_SEARCHING_RIDE -> "passenger_cancelled_searching_ride"
-                ApiCancellationReason.PASSENGER_CANCELLED_OFFERED_RIDE -> "passenger_cancelled_offered_ride"
-                ApiCancellationReason.PASSENGER_CANCELLED_WAITING_FOR_DRIVER -> "passenger_cancelled_waiting_for_driver"
-                ApiCancellationReason.PASSENGER_CANCELLED_AFTER_PICKUP -> "passenger_cancelled_after_pickup"
-                ApiCancellationReason.PASSENGER_CANCELLED_BOOKED_RIDE -> "passenger_cancelled_booked_ride"
-                ApiCancellationReason.DRIVER_CANCELLED -> "driver_cancelled"
-                ApiCancellationReason.DRIVER_REJECTED -> "driver_rejected"
-                ApiCancellationReason.NO_VEHICLE_AVAILABLE -> "no_vehicle_available"
-                ApiCancellationReason.PASSENGER_DID_NOT_ACCEPT_IN_TIME -> "passenger_did_not_accept_in_time"
-                ApiCancellationReason.DRIVER_DID_NOT_ACCEPT_IN_TIME -> "driver_did_not_accept_in_time"
-                ApiCancellationReason.RIDE_REQUEST_OUTDATED -> "ride_request_outdated"
-                ApiCancellationReason.TRANSACTIONAL_SAVE_FAILED -> "transactional_save_failed"
-                ApiCancellationReason.NO_STATIONS_FOUND -> "no_stations_found"
-                ApiCancellationReason.APPLY_FAILED -> "apply_failed"
-                ApiCancellationReason.NO_TASK_LIST_FOUND -> "no_task_list_found"
-                ApiCancellationReason.PROHIBIT_PARALLEL_FILTER -> "prohibit_parallel_filter"
-                ApiCancellationReason.OPERATOR_CANCELLED -> "operator_cancelled"
-                ApiCancellationReason.UNSUPPORTED -> "UNSUPPORTED"
-            },
-        )
-    }
-
-    @OptIn(ExperimentalSerializationApi::class)
-    override fun deserialize(decoder: Decoder): ApiCancellationReason? {
-        val stringValue =
-            decoder.decodeNullableSerializableValue(String.serializer().nullable) ?: return null
-
-        return when (stringValue) {
-            "passenger_cancelled" -> ApiCancellationReason.PASSENGER_CANCELLED
-            "passenger_cancelled_searching_ride" -> ApiCancellationReason.PASSENGER_CANCELLED_SEARCHING_RIDE
-            "passenger_cancelled_offered_ride" -> ApiCancellationReason.PASSENGER_CANCELLED_OFFERED_RIDE
-            "passenger_cancelled_waiting_for_driver" -> ApiCancellationReason.PASSENGER_CANCELLED_WAITING_FOR_DRIVER
-            "passenger_cancelled_after_pickup" -> ApiCancellationReason.PASSENGER_CANCELLED_AFTER_PICKUP
-            "passenger_cancelled_booked_ride" -> ApiCancellationReason.PASSENGER_CANCELLED_BOOKED_RIDE
-            "driver_cancelled" -> ApiCancellationReason.DRIVER_CANCELLED
-            "driver_rejected" -> ApiCancellationReason.DRIVER_REJECTED
-            "no_vehicle_available" -> ApiCancellationReason.NO_VEHICLE_AVAILABLE
-            "passenger_did_not_accept_in_time" -> ApiCancellationReason.PASSENGER_DID_NOT_ACCEPT_IN_TIME
-            "driver_did_not_accept_in_time" -> ApiCancellationReason.DRIVER_DID_NOT_ACCEPT_IN_TIME
-            "ride_request_outdated" -> ApiCancellationReason.RIDE_REQUEST_OUTDATED
-            "transactional_save_failed" -> ApiCancellationReason.TRANSACTIONAL_SAVE_FAILED
-            "no_stations_found" -> ApiCancellationReason.NO_STATIONS_FOUND
-            "apply_failed" -> ApiCancellationReason.APPLY_FAILED
-            "no_task_list_found" -> ApiCancellationReason.NO_TASK_LIST_FOUND
-            "prohibit_parallel_filter" -> ApiCancellationReason.PROHIBIT_PARALLEL_FILTER
-            "operator_cancelled" -> ApiCancellationReason.OPERATOR_CANCELLED
-            else -> ApiCancellationReason.UNSUPPORTED
-        }
-    }
-}

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiCancellationReasonTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiCancellationReasonTest.kt
@@ -95,6 +95,10 @@ internal class ApiCancellationReasonTest {
                         "\"prohibit_parallel_filter\"",
                     ),
                     arrayOf(
+                        ApiCancellationReason.OPERATOR_CANCELLED,
+                        "\"operator_cancelled\"",
+                    ),
+                    arrayOf(
                         ApiCancellationReason.UNSUPPORTED,
                         "\"UNSUPPORTED\"",
                     ),


### PR DESCRIPTION
## Related Issue
<!--- If this is a feature or a bug fix, make sure to link the related issue here -->
part of https://github.com/dbdrive/backlog/issues/2511

## Description
<!--- Describe your changes -->

We have to distringuesh between "was cancelled by passenger or operator".
For that, we need this flag...

## Test artifact

**Test models updated?**

In case you created a new APIObject or extracted one,
make sure to update the test fakes in [`test/src/commonMain/models`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test/models) as well.

Changes to existing models will probably fail on testing and are noticed by the CI.

**Test services updated?**

In case you created a new service or extracted one,
make sure to update the test fakes in [`test/src/commonMain/services`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test) as well.

Changes to existing services will probably fail on testing and are noticed by the CI.
