### PR TITLE
Updates to ticketingService

### DIFF
--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/IokiService.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/IokiService.kt
@@ -352,6 +352,8 @@ public interface TicketingService {
         id: String,
         request: ApiRenewTicketingVoucherRequest,
     ): ApiResult<ApiTicketingVoucherResponse>
+
+    public suspend fun cancelTicketingVoucher(voucherId: String): ApiResult<ApiTicketingVoucherResponse>
 }
 
 public interface BootstrapService {
@@ -764,6 +766,11 @@ private class DefaultIokiService(
     ): ApiResult<ApiTicketingVoucherResponse> =
         apiCall<ApiBody<ApiTicketingVoucherResponse>, ApiTicketingVoucherResponse> {
             renewUserTicketingVoucher(id = id, body = ApiBody(request))
+        }
+
+    override suspend fun cancelTicketingVoucher(voucherId: String): ApiResult<ApiTicketingVoucherResponse> =
+        apiCall<ApiBody<ApiTicketingVoucherResponse>, ApiTicketingVoucherResponse> {
+            cancelUserTicketingVoucher(id = voucherId)
         }
 
     override suspend fun getActiveUserTicketingVouchers(page: Int): ApiResult<List<ApiTicketingVoucherResponse>> =

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/internal/api/IokiApi.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/internal/api/IokiApi.kt
@@ -434,6 +434,11 @@ internal class IokiApi(
             setBody(body)
         }
 
+    suspend fun cancelUserTicketingVoucher(id: String): HttpResponse =
+        client.post("/api/passenger/ticketing/vouchers/$id/subscription_cancellation") {
+            header("Authorization", accessToken)
+        }
+
     suspend fun getTicketShopConfiguration(): HttpResponse = client.get("/api/passenger/ticketing/shop_config") {
         header("Authorization", accessToken)
     }

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiTicketingVoucherResponse.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiTicketingVoucherResponse.kt
@@ -1,13 +1,20 @@
 package com.ioki.passenger.api.models
 
 import kotlinx.datetime.Instant
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 @Serializable
 public data class ApiTicketingVoucherResponse(
     val id: String,
-    val state: State = State.UNSUPPORTED,
+    @Serializable(with = ApiTicketingVoucherResponseStateSerializer::class)
+    val state: State,
     val price: ApiMoney,
     @SerialName(value = "product")
     val product: ApiTicketingProductResponse?,
@@ -55,4 +62,29 @@ public data class ApiTicketingVoucherResponse(
         @SerialName(value = "valid_from") val validFrom: Instant?,
         @SerialName(value = "valid_until") val validUntil: Instant?,
     )
+}
+
+internal object ApiTicketingVoucherResponseStateSerializer : KSerializer<ApiTicketingVoucherResponse.State> {
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("ApiTicketingVoucherResponseState")
+
+    override fun serialize(encoder: Encoder, value: ApiTicketingVoucherResponse.State) {
+        when (value) {
+            ApiTicketingVoucherResponse.State.INITIATED -> encoder.encodeString("initiated")
+            ApiTicketingVoucherResponse.State.CANCELLED -> encoder.encodeString("cancelled")
+            ApiTicketingVoucherResponse.State.ISSUED -> encoder.encodeString("issued")
+            ApiTicketingVoucherResponse.State.REDEEMED -> encoder.encodeString("redeemed")
+            ApiTicketingVoucherResponse.State.UNSUPPORTED -> encoder.encodeString("unsupported")
+        }
+    }
+
+    override fun deserialize(decoder: Decoder): ApiTicketingVoucherResponse.State {
+        val stringValue = decoder.decodeSerializableValue(String.serializer())
+        return when (stringValue) {
+            "initiated" -> ApiTicketingVoucherResponse.State.INITIATED
+            "cancelled" -> ApiTicketingVoucherResponse.State.CANCELLED
+            "issued" -> ApiTicketingVoucherResponse.State.ISSUED
+            "redeemed" -> ApiTicketingVoucherResponse.State.REDEEMED
+            else -> ApiTicketingVoucherResponse.State.UNSUPPORTED
+        }
+    }
 }

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiTicketingVoucherResponse.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiTicketingVoucherResponse.kt
@@ -37,7 +37,17 @@ public data class ApiTicketingVoucherResponse(
         @SerialName(value = "validity_information") val validityInformation: String,
         @SerialName(value = "valid_from") val validFrom: Instant?,
         @SerialName(value = "valid_until") val validUntil: Instant?,
-    )
+        @SerialName(value = "vendor_ticket_details") val vendorTicketDetails: VendorTicketDetails?,
+    ) {
+        @Serializable
+        public data class VendorTicketDetails(
+            @SerialName(value = "customer_code") val customerCode: String,
+            @SerialName(value = "full_name") val fullName: String,
+            val host: String,
+            val issuer: String,
+            @SerialName(value = "purchase_id") val purchaseId: String,
+        )
+    }
 
     @Serializable
     public data class RenewalInformation(

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiTicketingVoucherResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiTicketingVoucherResponseTest.kt
@@ -1,0 +1,150 @@
+package com.ioki.passenger.api.models
+
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+
+internal class ApiTicketingVoucherResponseTest : IokiApiModelTest() {
+    @Test
+    fun serialization() {
+        testJsonStringCanBeConvertedToModel(
+            ApiTicketingVoucherResponse(
+                id = "1",
+                state = ApiTicketingVoucherResponse.State.UNSUPPORTED,
+                price = ApiMoney(
+                    amount = 1,
+                    currency = "EUR",
+                ),
+                product = ApiTicketingProductResponse(
+                    id = "",
+                    type = "",
+                    createdAt = null,
+                    updatedAt = Instant.parse("2021-09-10T10:00:00Z"),
+                    providerId = "",
+                    ticketingVendorId = "",
+                    slug = "",
+                    name = "",
+                    description = "",
+                    purchasable = false,
+                    purchasableFrom = null,
+                    purchasableUntil = null,
+                    priceType = ApiTicketingProductResponse.PriceType.UNSUPPORTED,
+                    price = ApiMoney(
+                        amount = 0,
+                        currency = "",
+                    ),
+                    purchaseOptions = emptyList(),
+                    redemptionOptions = emptyList(),
+                ),
+                ticket = ApiTicketingVoucherResponse.Ticket(
+                    id = "",
+                    webviewUrl = null,
+                    validityInformation = "",
+                    validFrom = null,
+                    validUntil = null,
+                    vendorTicketDetails = ApiTicketingVoucherResponse.Ticket.VendorTicketDetails(
+                        customerCode = "",
+                        fullName = "",
+                        host = "",
+                        issuer = "",
+                        purchaseId = "",
+                    ),
+                ),
+                renewalInformation = ApiTicketingVoucherResponse.RenewalInformation(
+                    renewable = false,
+                    validFrom = null,
+                    validUntil = null,
+                ),
+            ),
+            ticketingVoucherResponse,
+        )
+    }
+
+    @Test
+    fun serializationMinimal() {
+        testJsonStringCanBeConvertedToModel(
+            ApiTicketingVoucherResponse(
+                id = "1",
+                state = ApiTicketingVoucherResponse.State.INITIATED,
+                price = ApiMoney(
+                    amount = 1,
+                    currency = "EUR",
+                ),
+                product = null,
+                ticket = null,
+                renewalInformation = ApiTicketingVoucherResponse.RenewalInformation(
+                    renewable = false,
+                    validFrom = null,
+                    validUntil = null,
+                ),
+            ),
+            ticketingVoucherResponseMinimal,
+        )
+    }
+}
+
+private val ticketingVoucherResponse = """
+{
+    "id": "1",
+    "state": "unsupported",
+    "price": {
+        "amount": 1,
+        "currency": "EUR"
+    },
+    "product": {
+        "id": "",
+        "type": "",
+        "created_at": null,
+        "updated_at": "2021-09-10T10:00:00Z",
+        "provider_id": "",
+        "ticketing_vendor_id": "",
+        "slug": "",
+        "name": "",
+        "description": "",
+        "purchasable": false,
+        "purchasable_from": null,
+        "purchasable_until": null,
+        "price_type": "unsupported",
+        "price": {
+            "amount": 0,
+            "currency": ""
+        },
+        "purchase_options": [],
+        "redemption_options": []
+    },
+    "ticket": {
+        "id": "",
+        "webview_url": null,
+        "validity_information": "",
+        "valid_from": null,
+        "valid_until": null,
+        "vendor_ticket_details": {
+            "customer_code": "",
+            "full_name": "",
+            "host": "",
+            "issuer": "",
+            "purchase_id": ""
+        }
+    },
+    "renewal_information": {
+        "renewable": false,
+        "valid_from": null,
+        "valid_until": null
+    }
+}
+""".trimIndent()
+
+private val ticketingVoucherResponseMinimal = """
+{
+    "id": "1",
+    "state": "initiated",
+    "price": {
+        "amount": 1,
+        "currency": "EUR"
+    },
+    "renewal_information": {
+        "renewable": false,
+        "valid_from": null,
+        "valid_until": null
+    }
+}
+""".trimIndent()

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/FakeTicketingService.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/FakeTicketingService.kt
@@ -37,4 +37,7 @@ public open class FakeTicketingService : TicketingService {
         id: String,
         request: ApiRenewTicketingVoucherRequest,
     ): ApiResult<ApiTicketingVoucherResponse> = error("Not overridden")
+
+    override suspend fun cancelTicketingVoucher(voucherId: String): ApiResult<ApiTicketingVoucherResponse> =
+        error("Not overridden")
 }

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiTicketingVoucherResponse.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiTicketingVoucherResponse.kt
@@ -27,12 +27,28 @@ public fun createApiTicketingVoucherTicket(
     validityInformation: String = "",
     validFrom: Instant? = null,
     validUntil: Instant? = null,
+    vendorTicketDetails: ApiTicketingVoucherResponse.Ticket.VendorTicketDetails? = null,
 ): ApiTicketingVoucherResponse.Ticket = ApiTicketingVoucherResponse.Ticket(
     id = id,
     webviewUrl = webviewUrl,
     validityInformation = validityInformation,
     validFrom = validFrom,
     validUntil = validUntil,
+    vendorTicketDetails = vendorTicketDetails,
+)
+
+public fun createApiTicketingVoucherTicketVendorTicketDetails(
+    customerCode: String = "",
+    fullName: String = "",
+    host: String = "",
+    issuer: String = "",
+    purchaseId: String = "",
+): ApiTicketingVoucherResponse.Ticket.VendorTicketDetails = ApiTicketingVoucherResponse.Ticket.VendorTicketDetails(
+    customerCode = customerCode,
+    fullName = fullName,
+    host = host,
+    issuer = issuer,
+    purchaseId = purchaseId,
 )
 
 public fun createApiTicketingVoucherRenewalInformation(


### PR DESCRIPTION
## Related Issue
<!--- If this is a feature or a bug fix, make sure to link the related issue here -->
[internal](https://github.com/dbdrive/backlog/issues/2148) 

## Description
1. Add missing voucher cancellation endpoint
Realized that we miss that endpoint while refactoring our internal code base to it.
2. Added `vendor_ticket_details` to the ticketing voucher

## Test artifact

**Test models updated?**

In case you created a new APIObject or extracted one,
make sure to update the test fakes in [`test/src/commonMain/models`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test/models) as well.

Changes to existing models will probably fail on testing and are noticed by the CI.

**Test services updated?**

In case you created a new service or extracted one,
make sure to update the test fakes in [`test/src/commonMain/services`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test) as well.

Changes to existing services will probably fail on testing and are noticed by the CI.
