### PR TITLE
Fix query parameters

### DIFF
--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/internal/api/IokiApi.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/internal/api/IokiApi.kt
@@ -43,6 +43,7 @@ import io.ktor.client.request.patch
 import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
+import io.ktor.client.request.url
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.parameters
 import kotlinx.datetime.Instant
@@ -103,20 +104,24 @@ internal class IokiApi(
     suspend fun getRides(type: String, page: Int = 1, perPage: Int = 10): HttpResponse =
         client.get("/api/passenger/rides") {
             header("Authorization", accessToken)
-            parameters {
-                append("filter", type)
-                append("page", page.toString())
-                append("per_page", perPage.toString())
-            }
+            url.parameters.appendAll(
+                parameters {
+                    append("filter", type)
+                    append("page", page.toString())
+                    append("per_page", perPage.toString())
+                },
+            )
         }
 
     suspend fun getRideSeriesList(page: Int = 1, perPage: Int = 10): HttpResponse =
         client.get("/api/passenger/ride_series") {
             header("Authorization", accessToken)
-            parameters {
-                append("page", page.toString())
-                append("per_page", perPage.toString())
-            }
+            url.parameters.appendAll(
+                parameters {
+                    append("page", page.toString())
+                    append("per_page", perPage.toString())
+                },
+            )
         }
 
     suspend fun getRideSeries(rideSeriesId: String): HttpResponse =
@@ -205,8 +210,13 @@ internal class IokiApi(
 
     suspend fun requestPublicTransportSchedules(url: String, time: Instant): HttpResponse = client.get(url) {
         header("Authorization", accessToken)
-        parameters {
-            append("time", time.toString())
+        url {
+            url(url)
+            parameters.appendAll(
+                parameters {
+                    append("time", time.toString())
+                },
+            )
         }
     }
 
@@ -330,14 +340,16 @@ internal class IokiApi(
         ymax: Float?,
     ): HttpResponse = client.get("/api/passenger/stations") {
         header("Authorization", accessToken)
-        parameters {
-            append("query", query)
-            append("product_id", productId)
-            append("xmin", xmin.toString())
-            append("xmax", xmax.toString())
-            append("ymin", ymin.toString())
-            append("ymax", ymax.toString())
-        }
+        url.parameters.appendAll(
+            parameters {
+                append("query", query)
+                append("product_id", productId)
+                xmin?.let { append("xmin", it.toString()) }
+                xmax?.let { append("xmax", it.toString()) }
+                ymin?.let { append("ymin", it.toString()) }
+                ymax?.let { append("ymax", it.toString()) }
+            },
+        )
     }
 
     suspend fun getVenues(): HttpResponse = client.get("/api/passenger/venues") {
@@ -389,12 +401,14 @@ internal class IokiApi(
         perPage: Int = 10,
     ): HttpResponse = client.get("/api/passenger/ticketing/products") {
         header("Authorization", accessToken)
-        parameters {
-            append("filter", filter)
-            append("ride_id", rideId.toString())
-            append("page", page.toString())
-            append("per_page", perPage.toString())
-        }
+        url.parameters.appendAll(
+            parameters {
+                append("filter", filter)
+                rideId?.let { append("ride_id", it.toString()) }
+                append("page", page.toString())
+                append("per_page", perPage.toString())
+            },
+        )
     }
 
     suspend fun purchaseTicketingProduct(id: String, body: ApiBody<ApiPurchaseTicketingProductRequest>): HttpResponse =
@@ -406,21 +420,25 @@ internal class IokiApi(
     suspend fun getActiveUserTicketingVouchers(page: Int, perPage: Int = 10): HttpResponse =
         client.get("/api/passenger/ticketing/vouchers") {
             header("Authorization", accessToken)
-            parameters {
-                append("page", page.toString())
-                append("filter", "active")
-                append("per_page", perPage.toString())
-            }
+            url.parameters.appendAll(
+                parameters {
+                    append("page", page.toString())
+                    append("filter", "active")
+                    append("per_page", perPage.toString())
+                },
+            )
         }
 
     suspend fun getInactiveUserTicketingVouchers(page: Int, perPage: Int = 10): HttpResponse =
         client.get("/api/passenger/ticketing/vouchers") {
             header("Authorization", accessToken)
-            parameters {
-                append("page", page.toString())
-                append("filter", "inactive")
-                append("per_page", perPage.toString())
-            }
+            url.parameters.appendAll(
+                parameters {
+                    append("page", page.toString())
+                    append("filter", "inactive")
+                    append("per_page", perPage.toString())
+                },
+            )
         }
 
     suspend fun getUserTicketingVoucher(id: String): HttpResponse =

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/internal/api/IokiApiParameters.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/internal/api/IokiApiParameters.kt
@@ -1,0 +1,147 @@
+package com.ioki.passenger.api.internal.api
+
+import com.ioki.passenger.api.FakeHttpClient
+import com.ioki.passenger.api.internal.authorisation.AuthHeaderProvider
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class IokiApiParameters {
+
+    @Test
+    fun `test getRides parameters`() = runTest {
+        val parameters = setupParameterTest {
+            it.getRides(type = "type", page = 5, perPage = 10)
+        }
+
+        assertTrue(parameters.contains("filter", "type"))
+        assertTrue(parameters.contains("page", "5"))
+        assertTrue(parameters.contains("per_page", "10"))
+    }
+
+    @Test
+    fun `test rideSeriesList parameters`() = runTest {
+        val parameters = setupParameterTest {
+            it.getRideSeriesList(page = 5)
+        }
+
+        assertTrue(parameters.contains("page", "5"))
+        assertTrue(parameters.contains("per_page", "10"))
+    }
+
+    @Test
+    fun `test requestPublicTransportSchedules parameters`() = runTest {
+        val time = Instant.DISTANT_PAST
+        val parameters = setupParameterTest {
+            it.requestPublicTransportSchedules(
+                url = "https://ioki.com",
+                time = time,
+            )
+        }
+
+        assertTrue(parameters.contains("time", time.toString()))
+    }
+
+    @Test
+    fun `test getStations with empty x and y parameters`() = runTest {
+        val parameters = setupParameterTest {
+            it.getStations(
+                query = "1.0",
+                productId = "productId",
+                xmin = null,
+                xmax = null,
+                ymin = null,
+                ymax = null,
+            )
+        }
+
+        assertTrue(parameters.contains("query", "1.0"))
+        assertTrue(parameters.contains("product_id", "productId"))
+    }
+
+    @Test
+    fun `test getStations with x and y parameters`() = runTest {
+        val parameters = setupParameterTest {
+            it.getStations(
+                query = "1.0",
+                productId = "productId",
+                xmin = 1.2f,
+                xmax = 1.0f,
+                ymin = 0.2f,
+                ymax = 2.4f,
+            )
+        }
+
+        assertTrue(parameters.contains("query", "1.0"))
+        assertTrue(parameters.contains("product_id", "productId"))
+        assertTrue(parameters.contains("xmin", "1.2"))
+        assertTrue(parameters.contains("xmax", "1.0"))
+        assertTrue(parameters.contains("ymin", "0.2"))
+        assertTrue(parameters.contains("ymax", "2.4"))
+    }
+
+    @Test
+    fun `test getAllTicketingProducts parameters`() = runTest {
+        val parameters = setupParameterTest {
+            it.getAllTicketingProducts(
+                filter = "filter",
+                rideId = "rideId",
+                page = 2,
+                perPage = 100,
+            )
+        }
+
+        assertTrue(parameters.contains("filter", "filter"))
+        assertTrue(parameters.contains("ride_id", "rideId"))
+        assertTrue(parameters.contains("page", "2"))
+        assertTrue(parameters.contains("per_page", "100"))
+    }
+
+    @Test
+    fun `test getActiveUserTicketingVouchers parameters`() = runTest {
+        val parameters = setupParameterTest {
+            it.getActiveUserTicketingVouchers(
+                page = 2,
+                perPage = 100,
+            )
+        }
+
+        assertTrue(parameters.contains("page", "2"))
+        assertTrue(parameters.contains("per_page", "100"))
+    }
+
+    @Test
+    fun `test getInactiveTicketingVouchers parameters`() = runTest {
+        val parameters = setupParameterTest {
+            it.getInactiveUserTicketingVouchers(
+                page = 2,
+                perPage = 100,
+            )
+        }
+
+        assertTrue(parameters.contains("page", "2"))
+        assertTrue(parameters.contains("per_page", "100"))
+    }
+
+    private suspend fun setupParameterTest(apiCallToTest: suspend (IokiApi) -> HttpResponse): Parameters {
+        val client = FakeHttpClient(HttpStatusCode.OK, ByteReadChannel.Empty)
+        val api = IokiApi(
+            client,
+            object : AuthHeaderProvider {
+                override fun provide(): String = "Doesn't matter"
+            },
+        )
+
+        apiCallToTest(api)
+
+        val requestData = (client.engine as MockEngine).requestHistory.first()
+        println(requestData.url)
+        return requestData.url.parameters
+    }
+}


### PR DESCRIPTION
## Related Issue
<!--- If this is a feature or a bug fix, make sure to link the related issue here -->
closes n/a

## Description
<!--- Describe your changes -->
The `parameters {}` function is just a public function that returns `Parameters`.
See https://api.ktor.io/ktor-http/io.ktor.http/parameters.html
So actually, we created `Parameters` but never added it to the `url`.

This PR fixes it.
See also the docs:
https://ktor.io/docs/client-requests.html#query_parameters

You can test this by simply drop the last commit (where I added the fix) and run the tests.

## Test artifact

**Test models updated?**

In case you created a new APIObject or extracted one,
make sure to update the test fakes in [`test/src/commonMain/models`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test/models) as well.

Changes to existing models will probably fail on testing and are noticed by the CI.

**Test services updated?**

In case you created a new service or extracted one,
make sure to update the test fakes in [`test/src/commonMain/services`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test) as well.

Changes to existing services will probably fail on testing and are noticed by the CI.
