### PR TITLE
Add kotest-assertions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ ktor = "3.1.2"
 ktlintVersion = "12.2.0"
 kotlinCoroutines = "1.10.2"
 result = "0.3.0"
+kotest = "5.9.1"
 
 [libraries]
 kotlinx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
@@ -23,6 +24,8 @@ ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "kto
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 
 result = { module = "com.ioki.result:result", version.ref = "result" }
+
+kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 
 [plugins]
 androidLibrary = { id = "com.android.library", version.ref = "agp" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -39,6 +39,7 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(libs.kotlin.test)
+                implementation(libs.kotest.assertions.core)
                 implementation(libs.kotlin.coroutines.test)
                 implementation(libs.ktor.client.mock)
                 implementation(project(":test"))

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/IokiServiceTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/IokiServiceTest.kt
@@ -9,11 +9,12 @@ import com.ioki.result.failureOrNull
 import com.ioki.result.map
 import com.ioki.result.mapFailure
 import com.ioki.result.successOrNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.http.HttpStatusCode
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
-import kotlin.test.assertTrue
 
 class IokiServiceTest {
 
@@ -27,7 +28,7 @@ class IokiServiceTest {
 
         val user = iokiService.getUser()
 
-        assertTrue(user is Result.Success<SuccessData<ApiAuthenticatedUserResponse>>)
+        user.shouldBeInstanceOf<Result.Success<SuccessData<ApiAuthenticatedUserResponse>>>()
     }
 
     @Test
@@ -49,7 +50,7 @@ class IokiServiceTest {
                 }
             }
 
-        assertTrue(user.successOrNull() == "John")
+        user.successOrNull() shouldBe "John"
     }
 
     @Test
@@ -65,7 +66,7 @@ class IokiServiceTest {
         when (user) {
             is Result.Failure<Error> -> error("Shouldn't be an error!")
             is Result.Success<SuccessData<ApiAuthenticatedUserResponse>> -> {
-                assertTrue(user.value.firstName == "John")
+                user.value.firstName shouldBe "John"
             }
         }
     }
@@ -89,7 +90,7 @@ class IokiServiceTest {
                 }
             }
 
-        assertTrue(user.failureOrNull() == "Api error. We might got an error? []")
+        user.failureOrNull() shouldBe "Api error. We might got an error? []"
     }
 }
 

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/MapApiErrorTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/MapApiErrorTest.kt
@@ -2,13 +2,13 @@ package com.ioki.passenger.api
 
 import com.ioki.passenger.api.models.ApiErrorBody
 import com.ioki.passenger.api.result.Error
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 internal class MapApiErrorTest {
 
@@ -35,8 +35,8 @@ internal class MapApiErrorTest {
 
         val result = mapApiError(fakeResponse, listOf(fakeApiErrorInterceptor))
 
-        assertTrue { result.error is Error.Api.Intercepted }
-        assertEquals(HttpStatusCode.NotAcceptable.value, result.error.httpStatusCode)
+        result.error.shouldBeInstanceOf<Error.Api.Intercepted>()
+        result.error.httpStatusCode shouldBe HttpStatusCode.NotAcceptable.value
     }
 
     @Test
@@ -52,8 +52,8 @@ internal class MapApiErrorTest {
 
         val result = mapApiError(fakeResponse, listOf(fakeApiErrorInterceptor))
 
-        assertTrue { result.error is Error.Api.Intercepted }
-        assertEquals(HttpStatusCode.Unauthorized.value, result.error.httpStatusCode)
+        result.error.shouldBeInstanceOf<Error.Api.Intercepted>()
+        result.error.httpStatusCode shouldBe HttpStatusCode.Unauthorized.value
     }
 
     @Test
@@ -69,8 +69,8 @@ internal class MapApiErrorTest {
 
         val result = mapApiError(fakeResponse, listOf(fakeApiErrorInterceptor))
 
-        assertTrue { result.error is Error.Api.Generic }
-        assertEquals(HttpStatusCode.BadGateway.value, result.error.httpStatusCode)
+        result.error.shouldBeInstanceOf<Error.Api.Generic>()
+        result.error.httpStatusCode shouldBe HttpStatusCode.BadGateway.value
     }
 
     @Test
@@ -89,7 +89,7 @@ internal class MapApiErrorTest {
 
         val result = mapApiError(fakeResponse, listOf())
 
-        assertTrue { result.error is Error.Api.Generic }
-        assertEquals(HttpStatusCode.NotAcceptable.value, result.error.httpStatusCode)
+        result.error.shouldBeInstanceOf<Error.Api.Generic>()
+        result.error.httpStatusCode shouldBe HttpStatusCode.NotAcceptable.value
     }
 }

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/MapSuccessTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/MapSuccessTest.kt
@@ -4,14 +4,14 @@ import com.ioki.passenger.api.models.ApiBody
 import com.ioki.passenger.api.models.ApiClientInfoResponse
 import com.ioki.passenger.api.result.SuccessData
 import com.ioki.result.Result
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertIs
 
 class MapSuccessTest {
 
@@ -55,9 +55,9 @@ class MapSuccessTest {
 
         val result = mapSuccess<ApiBody<ApiClientInfoResponse>, ApiClientInfoResponse>(response)
 
-        assertIs<Result.Success<SuccessData<ApiClientInfoResponse>>>(result)
-        assertEquals(result.data.value, apiClientInfoResponse)
-        assertEquals(result.data.meta, ApiBody.Meta(1, true))
+        result.shouldBeInstanceOf<Result.Success<SuccessData<ApiClientInfoResponse>>>()
+        result.data.value shouldBe apiClientInfoResponse
+        result.data.meta shouldBe ApiBody.Meta(1, true)
     }
 
     @Test
@@ -82,9 +82,9 @@ class MapSuccessTest {
 
         val result = mapSuccess<ApiClientInfoResponse, ApiClientInfoResponse>(response)
 
-        assertIs<Result.Success<SuccessData<ApiClientInfoResponse>>>(result)
-        assertEquals(result.data.value, apiClientInfoResponse)
-        assertEquals(result.data.meta, null)
+        result.shouldBeInstanceOf<Result.Success<SuccessData<ApiClientInfoResponse>>>()
+        result.data.value shouldBe apiClientInfoResponse
+        result.data.meta shouldBe null
     }
 
     @Test
@@ -103,7 +103,7 @@ class MapSuccessTest {
         val fakeHttpClient = FakeHttpClient(HttpStatusCode.OK, content)
         val response = fakeHttpClient.get("https://127.0.0.1")
 
-        assertFailsWith<IllegalArgumentException> {
+        shouldThrow<IllegalArgumentException> {
             mapSuccess<ApiBody<ApiClientInfoResponse?>, ApiClientInfoResponse>(response)
         }
     }

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/internal/api/IokiApiParameters.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/internal/api/IokiApiParameters.kt
@@ -6,15 +6,16 @@ import com.ioki.passenger.api.models.ApiPurchasableType
 import com.ioki.passenger.api.models.ApiPurchaseFilter
 import com.ioki.passenger.api.models.ApiPurchaseState
 import com.ioki.passenger.api.models.ApiPurchaseType
+import io.kotest.matchers.maps.shouldContainExactly
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
+import io.ktor.util.toMap
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
 import kotlin.test.Test
-import kotlin.test.assertTrue
 import kotlinx.datetime.Clock
 
 class IokiApiParameters {
@@ -25,9 +26,11 @@ class IokiApiParameters {
             it.getRides(type = "type", page = 5, perPage = 10)
         }
 
-        assertTrue(parameters.contains("filter", "type"))
-        assertTrue(parameters.contains("page", "5"))
-        assertTrue(parameters.contains("per_page", "10"))
+        parameters.toMap() shouldContainExactly mapOf(
+            "filter" to listOf("type"),
+            "page" to listOf("5"),
+            "per_page" to listOf("10"),
+        )
     }
 
     @Test
@@ -36,8 +39,10 @@ class IokiApiParameters {
             it.getRideSeriesList(page = 5)
         }
 
-        assertTrue(parameters.contains("page", "5"))
-        assertTrue(parameters.contains("per_page", "10"))
+        parameters.toMap() shouldContainExactly mapOf(
+            "page" to listOf("5"),
+            "per_page" to listOf("10"),
+        )
     }
 
     @Test
@@ -50,7 +55,9 @@ class IokiApiParameters {
             )
         }
 
-        assertTrue(parameters.contains("time", time.toString()))
+        parameters.toMap() shouldContainExactly mapOf(
+            "time" to listOf(time.toString()),
+        )
     }
 
     @Test
@@ -66,8 +73,10 @@ class IokiApiParameters {
             )
         }
 
-        assertTrue(parameters.contains("query", "1.0"))
-        assertTrue(parameters.contains("product_id", "productId"))
+        parameters.toMap() shouldContainExactly mapOf(
+            "query" to listOf("1.0"),
+            "product_id" to listOf("productId"),
+        )
     }
 
     @Test
@@ -83,12 +92,14 @@ class IokiApiParameters {
             )
         }
 
-        assertTrue(parameters.contains("query", "1.0"))
-        assertTrue(parameters.contains("product_id", "productId"))
-        assertTrue(parameters.contains("xmin", "1.2"))
-        assertTrue(parameters.contains("xmax", "1.0"))
-        assertTrue(parameters.contains("ymin", "0.2"))
-        assertTrue(parameters.contains("ymax", "2.4"))
+        parameters.toMap() shouldContainExactly mapOf(
+            "query" to listOf("1.0"),
+            "product_id" to listOf("productId"),
+            "xmin" to listOf("1.2"),
+            "xmax" to listOf("1.0"),
+            "ymin" to listOf("0.2"),
+            "ymax" to listOf("2.4"),
+        )
     }
 
     @Test
@@ -102,10 +113,12 @@ class IokiApiParameters {
             )
         }
 
-        assertTrue(parameters.contains("filter", "filter"))
-        assertTrue(parameters.contains("ride_id", "rideId"))
-        assertTrue(parameters.contains("page", "2"))
-        assertTrue(parameters.contains("per_page", "100"))
+        parameters.toMap() shouldContainExactly mapOf(
+            "filter" to listOf("filter"),
+            "ride_id" to listOf("rideId"),
+            "page" to listOf("2"),
+            "per_page" to listOf("100"),
+        )
     }
 
     @Test
@@ -117,8 +130,11 @@ class IokiApiParameters {
             )
         }
 
-        assertTrue(parameters.contains("page", "2"))
-        assertTrue(parameters.contains("per_page", "100"))
+        parameters.toMap() shouldContainExactly mapOf(
+            "filter" to listOf("active"),
+            "page" to listOf("2"),
+            "per_page" to listOf("100"),
+        )
     }
 
     @Test
@@ -130,8 +146,11 @@ class IokiApiParameters {
             )
         }
 
-        assertTrue(parameters.contains("page", "2"))
-        assertTrue(parameters.contains("per_page", "100"))
+        parameters.toMap() shouldContainExactly mapOf(
+            "filter" to listOf("inactive"),
+            "page" to listOf("2"),
+            "per_page" to listOf("100"),
+        )
     }
 
     @Test
@@ -154,16 +173,18 @@ class IokiApiParameters {
             )
         }
 
-        assertTrue(parameters.contains(name = "page", value = "2"))
-        assertTrue(parameters.contains(name = "per_page", value = "100"))
-        assertTrue(parameters.contains(name = "purchasable_id", value = "purchasableId"))
-        assertTrue(parameters.contains(name = "purchasable_type", value = "Booking"))
-        assertTrue(parameters.contains(name = "state", value = "failed"))
-        assertTrue(parameters.contains(name = "since", value = "1991-04-11T12:07:55Z"))
-        assertTrue(parameters.contains(name = "until", value = untilTime.toString()))
-        assertTrue(parameters.contains(name = "filter", value = "debit"))
-        assertTrue(parameters.contains(name = "order", value = "desc"))
-        assertTrue(parameters.contains(name = "order_by", value = "updated_at"))
+        parameters.toMap() shouldContainExactly mapOf(
+            "page" to listOf("2"),
+            "per_page" to listOf("100"),
+            "purchasable_id" to listOf("purchasableId"),
+            "purchasable_type" to listOf("Booking"),
+            "state" to listOf("failed"),
+            "since" to listOf("1991-04-11T12:07:55Z"),
+            "until" to listOf(untilTime.toString()),
+            "filter" to listOf("debit"),
+            "order" to listOf("desc"),
+            "order_by" to listOf("updated_at"),
+        )
     }
 
     private suspend fun setupParameterTest(apiCallToTest: suspend (IokiApi) -> HttpResponse): Parameters {
@@ -178,7 +199,6 @@ class IokiApiParameters {
         apiCallToTest(api)
 
         val requestData = (client.engine as MockEngine).requestHistory.first()
-        println(requestData.url)
         return requestData.url.parameters
     }
 }

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/internal/plugins/AuthorizationPluginTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/internal/plugins/AuthorizationPluginTest.kt
@@ -2,6 +2,8 @@ package com.ioki.passenger.api.internal.plugins
 
 import com.ioki.passenger.api.AccessTokenProvider
 import com.ioki.passenger.api.internal.authorisation.createAuthHeaderProvider
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -13,9 +15,6 @@ import io.ktor.http.headers
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
-import kotlin.test.assertIs
-import kotlin.test.expect
 
 internal class AuthorizationPluginTest {
 
@@ -39,12 +38,11 @@ internal class AuthorizationPluginTest {
         val apiClient = HttpClient(mockEngine) {
             install(AuthorizationPlugin)
         }
-        val exception = assertFailsWith<AccessTokenUnavailableException> {
+        shouldThrow<AccessTokenUnavailableException> {
             apiClient.get("http://localhost:8080") {
                 header(HttpHeaders.Authorization, fakeAuthProvider.provide())
             }
         }
-        assertIs<AccessTokenUnavailableException>(exception)
     }
 
     @Test
@@ -71,6 +69,6 @@ internal class AuthorizationPluginTest {
         val result = apiClient.get("http://localhost:8080") {
             header(HttpHeaders.Authorization, fakeAuthProvider.provide())
         }
-        expect(HttpStatusCode.OK) { result.status }
+        result.status shouldBe HttpStatusCode.OK
     }
 }

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/internal/plugins/DateHeaderPluginTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/internal/plugins/DateHeaderPluginTest.kt
@@ -1,6 +1,7 @@
 package com.ioki.passenger.api.internal.plugins
 
 import com.ioki.passenger.api.TimeOffsetProvider
+import io.kotest.matchers.shouldBe
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -15,7 +16,6 @@ import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.test.Test
-import kotlin.test.expect
 
 internal class DateHeaderPluginTest {
 
@@ -46,6 +46,6 @@ internal class DateHeaderPluginTest {
         apiClient.get("http://localhost:8080")
 
         val expectedLocalDateTime = LocalDateTime(1994, 11, 6, 8, 49, 37)
-        expect(expectedLocalDateTime) { receivedTime }
+        receivedTime shouldBe expectedLocalDateTime
     }
 }

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/internal/plugins/HttpLoggingPluginTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/internal/plugins/HttpLoggingPluginTest.kt
@@ -1,5 +1,6 @@
 package com.ioki.passenger.api.internal.plugins
 
+import io.kotest.matchers.shouldBe
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -13,7 +14,6 @@ import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
-import kotlin.test.expect
 
 internal class HttpLoggingPluginTest {
 
@@ -47,7 +47,7 @@ internal class HttpLoggingPluginTest {
             "Date: Sun, 06 Nov 1994 08:49:37 GMT",
             "{\"ip\":\"127.0.0.1\"}",
         )
-        expect(expected) { logText }
+        logText shouldBe expected
     }
 
     @Test
@@ -83,6 +83,6 @@ internal class HttpLoggingPluginTest {
             "Date: Sun, 06 Nov 1994 08:49:37 GMT",
             "{\"ip\":\"127.0.0.1\"}",
         )
-        expect(expected) { logText }
+        logText shouldBe expected
     }
 }

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiBookingStateTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiBookingStateTest.kt
@@ -1,13 +1,13 @@
 package com.ioki.passenger.api.models
 
+import io.kotest.matchers.shouldBe
 import kotlin.test.Test
-import kotlin.test.expect
 
 internal class ApiBookingStateTest {
     internal class ApiBookingStateTestExtra {
         @Test
         fun allCasesAreTested() {
-            expect(ApiBookingState.entries.size) { ApiBookingStateSerializationTest.data().size }
+            ApiBookingState.entries.size shouldBe ApiBookingStateSerializationTest.data().size
         }
     }
 

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiCancellationReasonTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiCancellationReasonTest.kt
@@ -1,15 +1,13 @@
 package com.ioki.passenger.api.models
 
+import io.kotest.matchers.shouldBe
 import kotlin.test.Test
-import kotlin.test.expect
 
 internal class ApiCancellationReasonTest {
     internal class ApiCancellationReasonTestExtra {
         @Test
         fun allCasesAreTested() {
-            expect(ApiCancellationReason.entries.size) {
-                ApiCancellationReasonSerializationTest.data().size
-            }
+            ApiCancellationReason.entries.size shouldBe ApiCancellationReasonSerializationTest.data().size
         }
     }
 

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiLocationTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiLocationTest.kt
@@ -1,9 +1,9 @@
 package com.ioki.passenger.api.models
 
 import com.ioki.passenger.api.test.models.createApiLocation
+import io.kotest.matchers.shouldBe
 import kotlinx.datetime.Instant
 import kotlin.test.Test
-import kotlin.test.expect
 
 internal class ApiLocationTest : IokiApiModelTest() {
     @Test
@@ -51,7 +51,7 @@ internal class ApiLocationTest : IokiApiModelTest() {
     fun `location hasDifferentPoint with stationId returns true`() {
         val location = createApiLocation(stationId = "stationId")
 
-        expect(location.hasDifferentPoint) { true }
+        location.hasDifferentPoint shouldBe true
     }
 
     @Test
@@ -61,7 +61,7 @@ internal class ApiLocationTest : IokiApiModelTest() {
             walkingDuration = null,
         )
 
-        expect(location.hasDifferentPoint) { false }
+        location.hasDifferentPoint shouldBe false
     }
 
     @Test
@@ -71,7 +71,7 @@ internal class ApiLocationTest : IokiApiModelTest() {
             walkingDuration = 0,
         )
 
-        expect(location.hasDifferentPoint) { false }
+        location.hasDifferentPoint shouldBe false
     }
 
     @Test
@@ -81,7 +81,7 @@ internal class ApiLocationTest : IokiApiModelTest() {
             walkingDuration = 500,
         )
 
-        expect(location.hasDifferentPoint) { true }
+        location.hasDifferentPoint shouldBe true
     }
 }
 

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiNotificationChannelTypeTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiNotificationChannelTypeTest.kt
@@ -1,13 +1,13 @@
 package com.ioki.passenger.api.models
 
+import io.kotest.matchers.shouldBe
 import kotlin.test.Test
-import kotlin.test.expect
 
 internal class ApiNotificationChannelTypeTest {
     internal class ApiNotificationChannelTypeTestExtra {
         @Test
         fun allCasesAreTested() {
-            expect(ApiNotificationChannelType.entries.size) { ApiNotificationChannelTypeSerializationTest.data().size }
+            ApiNotificationChannelType.entries.size shouldBe ApiNotificationChannelTypeSerializationTest.data().size
         }
     }
 

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPaymentMethodResponseTypeTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPaymentMethodResponseTypeTest.kt
@@ -1,15 +1,13 @@
 package com.ioki.passenger.api.models
 
+import io.kotest.matchers.shouldBe
 import kotlin.test.Test
-import kotlin.test.expect
 
 internal class ApiPaymentMethodResponseTypeTest {
     internal class ApiPaymentMethodResponseTypeTestExtra {
         @Test
         fun allCasesAreTested() {
-            expect(ApiPaymentMethodType.entries.size) {
-                ApiPaymentMethodResponseTypeSerializationTest.data().size
-            }
+            ApiPaymentMethodType.entries.size shouldBe ApiPaymentMethodResponseTypeSerializationTest.data().size
         }
     }
 

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiStripeTypeTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiStripeTypeTest.kt
@@ -1,13 +1,13 @@
 package com.ioki.passenger.api.models
 
+import io.kotest.matchers.shouldBe
 import kotlin.test.Test
-import kotlin.test.expect
 
 internal class ApiStripeTypeTest {
     internal class ApiStripeTypeTestExtra {
         @Test
         fun allCasesAreTested() {
-            expect(ApiStripeType.entries.size) { ApiStripeTypeSerializationTest.data().size }
+            ApiStripeType.entries.size shouldBe ApiStripeTypeSerializationTest.data().size
         }
     }
 

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/IokiApiModelTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/IokiApiModelTest.kt
@@ -1,17 +1,17 @@
 package com.ioki.passenger.api.models
 
 import com.ioki.passenger.api.internal.utils.createJson
-import kotlin.test.assertEquals
+import io.kotest.matchers.shouldBe
 
 internal abstract class IokiApiModelTest {
     inline fun <reified T : Any> testJsonStringCanBeConvertedToModel(expectedModel: T, jsonString: String) {
         val fromJson = createJson().decodeFromString<T>(jsonString)
-        assertEquals(expected = expectedModel, actual = fromJson)
+        fromJson shouldBe expectedModel
     }
 
     inline fun <reified T : Any> testModelCanBeConvertedToJsonString(expectedJsonString: String, model: T) {
         val json = createJson().encodeToString(model)
-        assertEquals(expected = expectedJsonString.normalize, actual = json)
+        json shouldBe expectedJsonString.normalize
     }
 
     private val String.normalize: String get() = replace("\\s+".toRegex(), "")


### PR DESCRIPTION
## Related Issue
<!--- If this is a feature or a bug fix, make sure to link the related issue here -->
closes #28 

## Description
<!--- Describe your changes -->
Using `assertEquals` or `assertTrue` doesn't provide the best expirience.
Looking at klibs.io revelas that kotest has a quite nice multiplatform assertion lib.
See https://kotest.io/docs/assertions/core-matchers.html

I decided to go with that - but I'm open for other suggestions 🤷 

## Test artifact

**Test models updated?**

In case you created a new APIObject or extracted one,
make sure to update the test fakes in [`test/src/commonMain/models`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test/models) as well.

Changes to existing models will probably fail on testing and are noticed by the CI.

**Test services updated?**

In case you created a new service or extracted one,
make sure to update the test fakes in [`test/src/commonMain/services`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test) as well.

Changes to existing services will probably fail on testing and are noticed by the CI.
