### PR TITLE
ApiFareResponse: Replace showCustomMessage with externalPricingCustomMessage

### DIFF
--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiFareResponse.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiFareResponse.kt
@@ -11,7 +11,7 @@ public data class ApiFareResponse(
     @SerialName(value = "booking_price_type")
     val bookingPriceType: BookingPriceType = BookingPriceType.UNSUPPORTED,
     @SerialName(value = "final_price") val finalPrice: ApiMoney?,
-    @SerialName(value = "custom_message_for_external_pricing") val externalPricingCustomMessage: String?,
+    @SerialName(value = "custom_message_for_external_pricing") val customMessageForExternalPricing: String?,
 ) : Entity {
     @Serializable
     public enum class BookingPriceType {

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiFareResponse.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiFareResponse.kt
@@ -11,7 +11,7 @@ public data class ApiFareResponse(
     @SerialName(value = "booking_price_type")
     val bookingPriceType: BookingPriceType = BookingPriceType.UNSUPPORTED,
     @SerialName(value = "final_price") val finalPrice: ApiMoney?,
-    @SerialName(value = "show_custom_message") val showCustomMessage: Boolean,
+    @SerialName(value = "custom_message_for_external_pricing") val externalPricingCustomMessage: String?,
 ) : Entity {
     @Serializable
     public enum class BookingPriceType {

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiFareResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiFareResponseTest.kt
@@ -12,7 +12,7 @@ internal class ApiFareResponseTest : IokiApiModelTest() {
                 bookingPrice = ApiMoney(100, "EUR"),
                 bookingPriceType = ApiFareResponse.BookingPriceType.MAX,
                 finalPrice = ApiMoney(95, "EUR"),
-                showCustomMessage = false,
+                externalPricingCustomMessage = "custom_message",
             ),
             fare,
         )
@@ -27,7 +27,7 @@ internal class ApiFareResponseTest : IokiApiModelTest() {
                 bookingPrice = ApiMoney(100, "EUR"),
                 bookingPriceType = ApiFareResponse.BookingPriceType.ESTIMATE,
                 finalPrice = null,
-                showCustomMessage = false,
+                externalPricingCustomMessage = null,
             ),
             fareMinimal,
         )
@@ -48,7 +48,7 @@ private val fare =
     "amount": 95,
     "currency": "EUR"
   },
-  "show_custom_message": false
+  "custom_message_for_external_pricing": "custom_message"
 }
 """
 
@@ -61,7 +61,6 @@ private val fareMinimal =
     "amount": 100,
     "currency": "EUR"
   },
-  "booking_price_type": "estimate",
-  "show_custom_message": false
+  "booking_price_type": "estimate"
 }
 """

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiFareResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiFareResponseTest.kt
@@ -12,7 +12,7 @@ internal class ApiFareResponseTest : IokiApiModelTest() {
                 bookingPrice = ApiMoney(100, "EUR"),
                 bookingPriceType = ApiFareResponse.BookingPriceType.MAX,
                 finalPrice = ApiMoney(95, "EUR"),
-                externalPricingCustomMessage = "custom_message",
+                customMessageForExternalPricing = "custom_message",
             ),
             fare,
         )
@@ -27,7 +27,7 @@ internal class ApiFareResponseTest : IokiApiModelTest() {
                 bookingPrice = ApiMoney(100, "EUR"),
                 bookingPriceType = ApiFareResponse.BookingPriceType.ESTIMATE,
                 finalPrice = null,
-                externalPricingCustomMessage = null,
+                customMessageForExternalPricing = null,
             ),
             fareMinimal,
         )

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideResponseTest.kt
@@ -92,7 +92,6 @@ internal class ApiRideResponseTest : IokiApiModelTest() {
                     bookingPriceType = ApiFareResponse.BookingPriceType.FIXED,
                     id = "far_123",
                     bookingPrice = ApiMoney(amount = 1000, currency = "EUR"),
-                    showCustomMessage = false,
                 ),
                 booking = ApiBooking(verificationCode = "ABC123"),
                 rating = ApiRatingResponse(
@@ -147,7 +146,6 @@ internal class ApiRideResponseTest : IokiApiModelTest() {
                             bookingPriceType = ApiFareResponse.BookingPriceType.FIXED,
                             id = "far_123",
                             bookingPrice = ApiMoney(1000, "EUR"),
-                            showCustomMessage = false,
                         ),
                         hops = listOf(
                             ApiOfferedSolution.Hop(
@@ -189,7 +187,6 @@ internal class ApiRideResponseTest : IokiApiModelTest() {
                         bookingPriceType = ApiFareResponse.BookingPriceType.FIXED,
                         id = "far_123",
                         bookingPrice = ApiMoney(1000, "EUR"),
-                        showCustomMessage = false,
                     ),
                     hops = listOf(
                         ApiOfferedSolution.Hop(

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiFareResponse.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiFareResponse.kt
@@ -16,5 +16,5 @@ public fun createApiFareResponse(
     bookingPrice = bookingPrice,
     bookingPriceType = bookingPriceType,
     finalPrice = finalPrice,
-    externalPricingCustomMessage = externalPricingCustomMessage,
+    customMessageForExternalPricing = externalPricingCustomMessage,
 )

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiFareResponse.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiFareResponse.kt
@@ -9,12 +9,12 @@ public fun createApiFareResponse(
     bookingPrice: ApiMoney = createApiMoney(),
     bookingPriceType: ApiFareResponse.BookingPriceType = ApiFareResponse.BookingPriceType.UNSUPPORTED,
     finalPrice: ApiMoney? = null,
-    showCustomMessage: Boolean = false,
+    externalPricingCustomMessage: String? = null,
 ): ApiFareResponse = ApiFareResponse(
     id = id,
     version = version,
     bookingPrice = bookingPrice,
     bookingPriceType = bookingPriceType,
     finalPrice = finalPrice,
-    showCustomMessage = showCustomMessage,
+    externalPricingCustomMessage = externalPricingCustomMessage,
 )


### PR DESCRIPTION
## Description
<!--- Describe your changes -->

Refactor ApiFareResponse to replace showCustomMessage with externalPricingCustomMessage

## Test artifact

**Test models updated?**

In case you created a new APIObject or extracted one,
make sure to update the test fakes in [`test/src/commonMain/models`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test/models) as well.

Changes to existing models will probably fail on testing and are noticed by the CI.

**Test services updated?**

In case you created a new service or extracted one,
make sure to update the test fakes in [`test/src/commonMain/services`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test) as well.

Changes to existing services will probably fail on testing and are noticed by the CI.
