### PR TITLE
ApiPaymentMethodRequest: Remove summary property

### DIFF
--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiFailedPaymentRequest.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiFailedPaymentRequest.kt
@@ -7,13 +7,6 @@ import kotlinx.serialization.Serializable
 public data class ApiFailedPaymentRequest(
     val amount: Int,
     @SerialName(value = "ride_ids") val rideIds: List<String>,
-    @SerialName(value = "payment_method") val paymentMethod: PaymentMethod,
+    @SerialName(value = "payment_method") val paymentMethod: ApiPaymentMethodRequest,
     @SerialName(value = "paypal_secure_element") val paypalSecureElement: String?,
-) {
-    @Serializable
-    public data class PaymentMethod(
-        @SerialName(value = "payment_method_type")
-        val paymentMethodType: ApiPaymentMethodType,
-        val id: String?,
-    )
-}
+)

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiPaymentMethodRequest.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiPaymentMethodRequest.kt
@@ -8,36 +8,4 @@ public data class ApiPaymentMethodRequest(
     @SerialName(value = "payment_method_type")
     val paymentMethodType: ApiPaymentMethodType,
     val id: String?,
-    val summary: Summary?,
-) {
-    @Serializable
-    public data class Summary(
-        val kind: Kind = Kind.UNSUPPORTED,
-        val title: String,
-        val expiration: String?,
-        @SerialName(value = "mandate_url")
-        val mandateUrl: String?,
-    ) {
-        @Serializable
-        public enum class Kind {
-            @SerialName(value = "card")
-            CREDIT_CARD,
-
-            @SerialName(value = "sepa_debit")
-            SEPA_DEBIT,
-
-            @SerialName(value = "paypal")
-            PAYPAL,
-
-            @SerialName(value = "cash")
-            CASH,
-
-            @SerialName(value = "service_credits")
-            SERVICE_CREDITS,
-
-            @SerialName(value = "pos_payment")
-            POS_PAYMENT,
-            UNSUPPORTED,
-        }
-    }
-}
+)

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiBookingRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiBookingRequestTest.kt
@@ -9,7 +9,7 @@ internal class ApiBookingRequestTest : IokiApiModelTest() {
             ApiBookingRequest(
                 rideVersion = 2,
                 solutionId = null,
-                paymentMethod = ApiPaymentMethodRequest(ApiPaymentMethodType.CASH, null, null),
+                paymentMethod = ApiPaymentMethodRequest(paymentMethodType = ApiPaymentMethodType.CASH, id = null),
                 paypalSecureElement = null,
             ),
             bookingRequestMinimal,
@@ -22,7 +22,7 @@ internal class ApiBookingRequestTest : IokiApiModelTest() {
             ApiBookingRequest(
                 rideVersion = 2,
                 solutionId = "solutionId",
-                paymentMethod = ApiPaymentMethodRequest(ApiPaymentMethodType.CASH, null, null),
+                paymentMethod = ApiPaymentMethodRequest(paymentMethodType = ApiPaymentMethodType.CASH, id = "abc123"),
                 paypalSecureElement = "secure_element",
             ),
             bookingRequest,
@@ -46,7 +46,8 @@ private val bookingRequest =
   "ride_version": 2,
   "solution_id": "solutionId",
   "payment_method": {
-    "payment_method_type": "cash"
+    "payment_method_type": "cash",
+    "id": "abc123"
   },
   "paypal_secure_element": "secure_element"
 }

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPurchasingCreditPackageRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPurchasingCreditPackageRequestTest.kt
@@ -12,7 +12,6 @@ internal class ApiPurchasingCreditPackageRequestTest : IokiApiModelTest() {
                 paymentMethod = ApiPaymentMethodRequest(
                     paymentMethodType = ApiPaymentMethodType.STRIPE,
                     id = null,
-                    summary = null,
                 ),
                 paypalSecureElement = null,
             ),
@@ -29,7 +28,6 @@ internal class ApiPurchasingCreditPackageRequestTest : IokiApiModelTest() {
                 paymentMethod = ApiPaymentMethodRequest(
                     paymentMethodType = ApiPaymentMethodType.STRIPE,
                     id = null,
-                    summary = null,
                 ),
                 paypalSecureElement = "secure_element",
             ),

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiUpdatePaymentMethodForRideRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiUpdatePaymentMethodForRideRequestTest.kt
@@ -10,7 +10,6 @@ internal class ApiUpdatePaymentMethodForRideRequestTest : IokiApiModelTest() {
                 paymentMethod = ApiPaymentMethodRequest(
                     paymentMethodType = ApiPaymentMethodType.STRIPE,
                     id = "pam_123",
-                    summary = null,
                 ),
                 rideVersion = 42,
                 paypalSecureElement = "1234",

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiPaymentMethodRequest.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiPaymentMethodRequest.kt
@@ -6,21 +6,7 @@ import com.ioki.passenger.api.models.ApiPaymentMethodType
 public fun createApiPaymentMethodRequest(
     paymentMethodType: ApiPaymentMethodType = ApiPaymentMethodType.UNSUPPORTED,
     id: String? = null,
-    summary: ApiPaymentMethodRequest.Summary? = null,
 ): ApiPaymentMethodRequest = ApiPaymentMethodRequest(
     paymentMethodType = paymentMethodType,
     id = id,
-    summary = summary,
-)
-
-public fun createApiPaymentMethodRequestSummary(
-    kind: ApiPaymentMethodRequest.Summary.Kind = ApiPaymentMethodRequest.Summary.Kind.UNSUPPORTED,
-    title: String = "",
-    expiration: String? = null,
-    mandateUrl: String? = null,
-): ApiPaymentMethodRequest.Summary = ApiPaymentMethodRequest.Summary(
-    kind = kind,
-    title = title,
-    expiration = expiration,
-    mandateUrl = mandateUrl,
 )


### PR DESCRIPTION
## Description
<!--- Describe your changes -->

The summary property is only available in `ApiPaymentMethodResponse`, not in `ApiPaymentMethodRequest`.
This PR removes the property.

## Test artifact

**Test models updated?**

In case you created a new APIObject or extracted one,
make sure to update the test fakes in [`test/src/commonMain/models`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test/models) as well.

Changes to existing models will probably fail on testing and are noticed by the CI.

**Test services updated?**

In case you created a new service or extracted one,
make sure to update the test fakes in [`test/src/commonMain/services`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test) as well.

Changes to existing services will probably fail on testing and are noticed by the CI.
