### PR TITLE
add HttpRequestTimeoutExcteption to connectivity error check

### DIFF
--- a/library/src/androidMain/kotlin/com/ioki/passenger/api/internal/utils/Actuals.android.kt
+++ b/library/src/androidMain/kotlin/com/ioki/passenger/api/internal/utils/Actuals.android.kt
@@ -1,6 +1,7 @@
 package com.ioki.passenger.api.internal.utils
 
 import io.ktor.client.network.sockets.SocketTimeoutException
+import io.ktor.client.plugins.HttpRequestTimeoutException
 import kotlinx.datetime.LocalDateTime
 import java.net.ConnectException
 import java.net.SocketException
@@ -13,6 +14,7 @@ internal actual val Throwable.isConnectivityError: Boolean
     get() =
         this is SocketException ||
             this is SocketTimeoutException ||
+            this is HttpRequestTimeoutException ||
             this is UnknownHostException ||
             this is ClosedChannelException ||
             this is ConnectException

--- a/library/src/appleMain/kotlin/com/ioki/passenger/api/internal/utils/Actuals.apple.kt
+++ b/library/src/appleMain/kotlin/com/ioki/passenger/api/internal/utils/Actuals.apple.kt
@@ -1,6 +1,7 @@
 package com.ioki.passenger.api.internal.utils
 
 import io.ktor.client.network.sockets.SocketTimeoutException
+import io.ktor.client.plugins.HttpRequestTimeoutException
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
@@ -15,7 +16,8 @@ import platform.Foundation.timeZoneForSecondsFromGMT
 private const val RFC1123_DATE_TIME_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz"
 
 internal actual val Throwable.isConnectivityError: Boolean
-    get() = this is SocketTimeoutException
+    get() = this is SocketTimeoutException ||
+        this is HttpRequestTimeoutException
 
 internal actual fun parseRfc1123DateTime(dateTimeString: String): LocalDateTime {
     val dateFormatter = NSDateFormatter().apply {

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/FakeHttpClient.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/FakeHttpClient.kt
@@ -12,7 +12,11 @@ import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.ByteReadChannel
 
 @Suppress("FunctionName")
-internal fun FakeHttpClient(statusCode: HttpStatusCode, content: ByteReadChannel, throws: Throwable? = null): HttpClient {
+internal fun FakeHttpClient(
+    statusCode: HttpStatusCode,
+    content: ByteReadChannel,
+    throws: Throwable? = null,
+): HttpClient {
     val mockEngine = MockEngine { _ ->
         if (throws != null) throw throws
         respond(

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/FakeHttpClient.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/FakeHttpClient.kt
@@ -12,8 +12,9 @@ import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.ByteReadChannel
 
 @Suppress("FunctionName")
-internal fun FakeHttpClient(statusCode: HttpStatusCode, content: ByteReadChannel): HttpClient {
+internal fun FakeHttpClient(statusCode: HttpStatusCode, content: ByteReadChannel, throws: Throwable? = null): HttpClient {
     val mockEngine = MockEngine { _ ->
+        if (throws != null) throw throws
         respond(
             content = content,
             status = statusCode,

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/IokiServiceTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/IokiServiceTest.kt
@@ -99,7 +99,10 @@ class IokiServiceTest {
         val httpResult = ByteReadChannel.Empty
         val iokiService = IokiService(
             accessTokenProvider = FakeAccessTokenProvider(),
-            iokiHttpClient = FakeHttpClient(HttpStatusCode.ServiceUnavailable, httpResult, throws = HttpRequestTimeoutException("", null, null)),
+            iokiHttpClient = FakeHttpClient(
+                statusCode = HttpStatusCode.ServiceUnavailable,
+                content = httpResult,
+                throws = HttpRequestTimeoutException("", null, null)),
         )
 
         val user = iokiService.getUser()

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/IokiServiceTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/IokiServiceTest.kt
@@ -102,7 +102,8 @@ class IokiServiceTest {
             iokiHttpClient = FakeHttpClient(
                 statusCode = HttpStatusCode.ServiceUnavailable,
                 content = httpResult,
-                throws = HttpRequestTimeoutException("", null, null)),
+                throws = HttpRequestTimeoutException("", null, null),
+            ),
         )
 
         val user = iokiService.getUser()

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/IokiServiceTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/IokiServiceTest.kt
@@ -11,6 +11,7 @@ import com.ioki.result.mapFailure
 import com.ioki.result.successOrNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.http.HttpStatusCode
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.test.runTest
@@ -91,6 +92,19 @@ class IokiServiceTest {
             }
 
         user.failureOrNull() shouldBe "Api error. We might got an error? []"
+    }
+
+    @Test
+    fun `getUser throws HttpTimeoutException`() = runTest {
+        val httpResult = ByteReadChannel.Empty
+        val iokiService = IokiService(
+            accessTokenProvider = FakeAccessTokenProvider(),
+            iokiHttpClient = FakeHttpClient(HttpStatusCode.ServiceUnavailable, httpResult, throws = HttpRequestTimeoutException("", null, null)),
+        )
+
+        val user = iokiService.getUser()
+
+        user.shouldBeInstanceOf<Result.Failure<Error.Connectivity>>()
     }
 }
 


### PR DESCRIPTION

## Description
<!--- Describe your changes -->

This exception was not being classified as a connectivity error which led to our app falsely logging this as an error. Because this can happen quite often, due to mobile internet issues, we need to add this to be correctly classified as a connectivity issue.