### PR TITLE
Make HTTP caching configurable

### DIFF
--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/IokiService.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/IokiService.kt
@@ -100,8 +100,9 @@ public fun IokiService(
     interceptors: Set<ApiErrorInterceptor> = setOf(),
     timeOffsetProvider: TimeOffsetProvider = NoopTimeOffsetProvider,
     logging: Logging? = null,
+    cachingEnabled: Boolean = true,
 ): IokiService {
-    val httpClient = IokiHttpClient(baseUrl, requestHeaders, timeOffsetProvider, logging)
+    val httpClient = IokiHttpClient(baseUrl, requestHeaders, timeOffsetProvider, logging, cachingEnabled)
     return IokiService(
         accessTokenProvider = accessTokenProvider,
         iokiHttpClient = httpClient,

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/internal/IokiHttpClient.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/internal/IokiHttpClient.kt
@@ -25,6 +25,7 @@ internal fun IokiHttpClient(
     requestHeaders: RequestHeaders,
     timeOffsetProvider: TimeOffsetProvider,
     logging: Logging?,
+    cachingEnabled: Boolean,
 ): IokiHttpClient = httpClient().config {
     install(ContentNegotiation) {
         json(createJson())
@@ -38,7 +39,10 @@ internal fun IokiHttpClient(
     install(DateHeaderPlugin) {
         offsetProvider = timeOffsetProvider
     }
-    install(HttpCache)
+
+    if (cachingEnabled) {
+        install(HttpCache)
+    }
 
     if (logging != null) {
         install(HttpLoggingPlugin) {


### PR DESCRIPTION
## Related Issue
https://github.com/ktorio/ktor/pull/4816

## Description
Internally, we run into the issue mentioned here:
https://youtrack.jetbrains.com/issue/KTOR-8345

As a bandaid we make the caching configurable and will disabled it for a few releases so our backend team or jetbrains/ktor has time to fix and release it.

## Test artifact

**Test models updated?**

In case you created a new APIObject or extracted one,
make sure to update the test fakes in [`test/src/commonMain/models`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test/models) as well.

Changes to existing models will probably fail on testing and are noticed by the CI.

**Test services updated?**

In case you created a new service or extracted one,
make sure to update the test fakes in [`test/src/commonMain/services`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test) as well.

Changes to existing services will probably fail on testing and are noticed by the CI.
