### PR TITLE
ApiPurchaseFilter: Use Int for page and perPage parameters

### DIFF
--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/internal/api/IokiApi.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/internal/api/IokiApi.kt
@@ -496,8 +496,8 @@ internal class IokiApi(
 }
 
 private fun ApiPurchaseFilter.toStringValues(): StringValues = StringValues.build {
-    append("page", page)
-    perPage?.let { append("per_page", it) }
+    append("page", page.toString())
+    perPage?.let { append("per_page", it.toString()) }
     since?.let { append("since", it.toString()) }
     until?.let { append("until", it.toString()) }
     purchasableId?.let { append("purchasable_id", it) }

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiPurchaseFilter.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiPurchaseFilter.kt
@@ -13,13 +13,13 @@ public data class ApiPurchaseFilter(
     @SerialName(value = "purchasable_id") val purchasableId: String? = null,
     @SerialName(value = "purchasable_type") val purchasableType: ApiPurchasableType? = null,
     val state: ApiPurchaseState? = null,
-    val page: String,
+    val page: Int,
     val since: Instant? = null,
     val until: Instant? = null,
     val filter: ApiPurchaseType? = null,
     val order: Order? = null,
     @SerialName(value = "order_by") val orderBy: OrderBy? = null,
-    @SerialName(value = "per_page") val perPage: String? = null,
+    @SerialName(value = "per_page") val perPage: Int? = null,
 ) {
     @Serializable(ApiPurchaseFilterOrderSerializer::class)
     public enum class Order {

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/internal/api/IokiApiParametersTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/internal/api/IokiApiParametersTest.kt
@@ -162,13 +162,13 @@ class IokiApiParametersTest {
                     purchasableId = "purchasableId",
                     purchasableType = ApiPurchasableType.BOOKING,
                     state = ApiPurchaseState.FAILED,
-                    page = "2",
+                    page = 2,
                     since = Instant.fromEpochSeconds(671371675),
                     until = untilTime,
                     filter = ApiPurchaseType.DEBIT,
                     order = ApiPurchaseFilter.Order.DESCENDING,
                     orderBy = ApiPurchaseFilter.OrderBy.UPDATED_AT,
-                    perPage = "100",
+                    perPage = 100,
                 ),
             )
         }


### PR DESCRIPTION
## Description
<!--- Describe your changes -->

In `ApiPurchaseFilter` type of `page` and `perPage` parameters is changed to integer.

## Test artifact

**Test models updated?**

In case you created a new APIObject or extracted one,
make sure to update the test fakes in [`test/src/commonMain/models`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test/models) as well.

Changes to existing models will probably fail on testing and are noticed by the CI.

**Test services updated?**

In case you created a new service or extracted one,
make sure to update the test fakes in [`test/src/commonMain/services`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test) as well.

Changes to existing services will probably fail on testing and are noticed by the CI.
