### PR TITLE
Replace ossrh plugin portal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Publish to Sonatype Staging
-        run: ./gradlew publishAllPublicationsToSonatypeStagingRepository -PGPG_SIGNING_REQUIRED --no-configuration-cache
+        run: ./gradlew publishAllPublicationsToSonatypeStagingRepository moveOssrhStagingToCentralPortal -PGPG_SIGNING_REQUIRED --no-configuration-cache
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # KMP Passenger API
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.ioki/passenger-api?labelColor=%2324292E&color=%233246c8)](https://central.sonatype.com/artifact/com.ioki/passenger-api)
-[![Snapshot](https://img.shields.io/nexus/s/com.ioki/passenger-api?labelColor=%2324292E&color=%234f78ff&server=https://s01.oss.sonatype.org)](https://s01.oss.sonatype.org/content/repositories/snapshots/com/ioki/passenger-api)
+<!-- Badge because of https://github.com/badges/shields/pull/10997
+[![Snapshot](https://img.shields.io/nexus/s/com.ioki/passenger-api?labelColor=%2324292E&color=%234f78ff&server=https://central.sonatype.com/repository/maven-snapshots/)](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/ioki/passenger-api/)
+-->
 
 ## Overview
 
@@ -46,14 +48,14 @@ val commonMain by getting {
 
 ```kotlin
 repositories {
-    maven(url = "https://s01.oss.sonatype.org/content/repositories/snapshots/")
+    maven(url = "https://central.sonatype.com/repository/maven-snapshots/")
 }
 
 val commonMain by getting {
     dependencies {
-        implementation("com.ioki:passenger-api:$currentVersion-SNAPSHOT")
+        implementation("com.ioki:passenger-api:$currentSnapshotVersion")
     }
-}    
+}
 ```
 </details>
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -31,9 +31,8 @@
 
 ### 5. Sign in to Sonatype and Close the Staged Repo
 
-   - Head to [Sonatype](https://s01.oss.sonatype.org/) and sign in (credentials are in the Bitwarden Open Source Collection).
-   - Search for the staged repo, click **Close**.
-   - After it's successfully **Closed**, click **Release** and check "Automatically drop".
+   - Head to the [Central Portal](https://central.sonatype.com/publishing/deployments) and sign in (credentials are in the Bitwarden Open Source Collection).
+   - Search for the artifacts you want to publish, click **Publish**.
 
 ### 6. Edit the Release on GitHub
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,3 +1,8 @@
+@file:OptIn(ExperimentalEncodingApi::class)
+
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
@@ -126,18 +131,23 @@ publishing {
     }
 
     repositories {
-        maven("https://s01.oss.sonatype.org/content/repositories/snapshots/") {
+        maven("https://central.sonatype.com/repository/maven-snapshots/") {
             name = "SonatypeSnapshot"
             credentials {
                 username = System.getenv("SONATYPE_USER")
                 password = System.getenv("SONATYPE_PASSWORD")
             }
         }
-        maven("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/") {
+        maven("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/") {
             name = "SonatypeStaging"
-            credentials {
-                username = System.getenv("SONATYPE_USER")
-                password = System.getenv("SONATYPE_PASSWORD")
+            credentials(HttpHeaderCredentials::class) {
+                name = "Authorization"
+                val bearerToken = "${System.getenv("SONATYPE_USER")}:${System.getenv("SONATYPE_PASSWORD")}"
+                val base64EncodedBearerToken = Base64.encode(bearerToken.toByteArray())
+                value = "Bearer $base64EncodedBearerToken"
+            }
+            authentication {
+                create<HttpHeaderAuthentication>("header")
             }
         }
     }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -89,6 +89,10 @@ val dokkaJar = tasks.register<Jar>("dokkaJar") {
     archiveClassifier.set("javadoc")
 }
 
+val base64EncodedBearerToken = Base64.encode(
+    "${System.getenv("SONATYPE_USER")}:${System.getenv("SONATYPE_PASSWORD")}".toByteArray(),
+)
+
 publishing {
     // Workaround for the Android target
     // withType<MavenPublication> does not work for Android target
@@ -142,8 +146,6 @@ publishing {
             name = "SonatypeStaging"
             credentials(HttpHeaderCredentials::class) {
                 name = "Authorization"
-                val bearerToken = "${System.getenv("SONATYPE_USER")}:${System.getenv("SONATYPE_PASSWORD")}"
-                val base64EncodedBearerToken = Base64.encode(bearerToken.toByteArray())
                 value = "Bearer $base64EncodedBearerToken"
             }
             authentication {
@@ -168,4 +170,19 @@ signing {
 tasks.withType<AbstractPublishToMaven>().configureEach {
     val signingTasks = tasks.withType<Sign>()
     mustRunAfter(signingTasks)
+}
+
+tasks.register<Exec>("moveOssrhStagingToCentralPortal") {
+    group = "publishing"
+    description = "Runs after publishAllPublicationsToSonatypeStagingRepository to move the artifacts to the central portal"
+
+    shouldRunAfter("publishAllPublicationsToSonatypeStagingRepository")
+
+    commandLine = listOf(
+        "curl",
+        "-f",
+        "-X", "POST",
+        "-H", "Authorization: Bearer $base64EncodedBearerToken",
+        "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/com.ioki",
+    )
 }

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -1,3 +1,8 @@
+@file:OptIn(ExperimentalEncodingApi::class)
+
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
@@ -92,18 +97,23 @@ publishing {
     }
 
     repositories {
-        maven("https://s01.oss.sonatype.org/content/repositories/snapshots/") {
+        maven("https://central.sonatype.com/repository/maven-snapshots/") {
             name = "SonatypeSnapshot"
             credentials {
                 username = System.getenv("SONATYPE_USER")
                 password = System.getenv("SONATYPE_PASSWORD")
             }
         }
-        maven("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/") {
+        maven("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/") {
             name = "SonatypeStaging"
-            credentials {
-                username = System.getenv("SONATYPE_USER")
-                password = System.getenv("SONATYPE_PASSWORD")
+            credentials(HttpHeaderCredentials::class) {
+                name = "Authorization"
+                val bearerToken = "${System.getenv("SONATYPE_USER")}:${System.getenv("SONATYPE_PASSWORD")}"
+                val base64EncodedBearerToken = Base64.encode(bearerToken.toByteArray())
+                value = "Bearer $base64EncodedBearerToken"
+            }
+            authentication {
+                create<HttpHeaderAuthentication>("header")
             }
         }
     }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c2889694-40da-4b80-81aa-4a941367198e)

OSSRH will reach end-of-life. So we have to replace it.
I already migrated our namespace.

The username and password on this repo is also replaced.

This PR here will adjust our publishing code.

See also our [internal ticket](https://github.com/dbdrive/beiwagen-android/issues/7610) for this.

## How to test:
Just run `publishAllPublicationsToSonatypeSnapshotRepository` or ``publishAllPublicationsToSonatypeStagingRepository moveOssrhStagingToCentralPortal` to publish to snapshot or staging respectively.

I published our snapshots already.
See https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/ioki/

After merge, I'll do a small 0.7.1 release to test if everything works.
