### PR TITLE
Fix warning

### DIFF
--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/IokiService.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/IokiService.kt
@@ -228,7 +228,7 @@ public interface CurrentRideService {
 
     public suspend fun updatePaymentMethodForRide(
         rideId: String,
-        body: ApiUpdatePaymentMethodForRideRequest,
+        request: ApiUpdatePaymentMethodForRideRequest,
     ): ApiResult<ApiRideResponse>
 }
 

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/FakeCurrentRideService.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/FakeCurrentRideService.kt
@@ -28,6 +28,6 @@ public open class FakeCurrentRideService : CurrentRideService {
 
     override suspend fun updatePaymentMethodForRide(
         rideId: String,
-        body: ApiUpdatePaymentMethodForRideRequest,
+        request: ApiUpdatePaymentMethodForRideRequest,
     ): ApiResult<ApiRideResponse> = error("Not overridden")
 }


### PR DESCRIPTION
![Screenshot 2025-05-13 at 2 50 12 PM](https://github.com/user-attachments/assets/82d15871-5f90-4a02-afe9-aa561fefe92e)

This fixes it.
It was named `body` in the `interface`, but `request` in the override.
I decided that `request` is better than body 🤓 
Yes, we might have breaking changes here.. 🤷 

