### PR TITLE
Use nmcp plugin to publish to central portal

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -22,4 +22,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Publish to Sonatype Snapshot
-        run: ./gradlew publishAllPublicationsToSonatypeSnapshotRepository -PGPG_SIGNING_REQUIRED --no-configuration-cache
+        run: ./gradlew publishAggregationToCentralSnapshots -PGPG_SIGNING_REQUIRED

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -22,4 +22,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Publish to Sonatype Snapshot
-        run: ./gradlew publishAggregationToCentralSnapshots -PGPG_SIGNING_REQUIRED
+        run: ./gradlew publishAllPublicationsToSonatypeSnapshotRepository -PGPG_SIGNING_REQUIRED --no-configuration-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Publish to Sonatype Staging
-        run: ./gradlew publishAllPublicationsToSonatypeStagingRepository moveOssrhStagingToCentralPortal -PGPG_SIGNING_REQUIRED --no-configuration-cache
+        run: ./gradlew publishAggregationToCentralPortal -PGPG_SIGNING_REQUIRED
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,20 @@
 plugins {
     alias(libs.plugins.androidLibrary).apply(false)
     alias(libs.plugins.kotlinMultiplatform).apply(false)
+    alias(libs.plugins.nmcpAggregation)
 }
 
-subprojects.forEach {
+allprojects.forEach {
     it.group = "com.ioki"
     it.version = "0.9.0-SNAPSHOT"
 }
 
+nmcpAggregation {
+    centralPortal {
+        username = System.getenv("SONATYPE_USER")
+        password = System.getenv("SONATYPE_PASSWORD")
+        publishingType = "USER_MANAGED"
+    }
+
+    publishAllProjectsProbablyBreakingProjectIsolation()
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,8 +11,8 @@ allprojects.forEach {
 
 nmcpAggregation {
     centralPortal {
-        username = System.getenv("SONATYPE_USER")
-        password = System.getenv("SONATYPE_PASSWORD")
+        username = providers.systemProperty("SONATYPE_USER")
+        password = providers.systemProperty("SONATYPE_PASSWORD")
         publishingType = "USER_MANAGED"
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ ktlintVersion = "12.2.0"
 kotlinCoroutines = "1.10.2"
 result = "0.3.0"
 kotest = "5.9.1"
+nmcp = "0.1.4"
 
 [libraries]
 kotlinx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
@@ -33,3 +34,4 @@ kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref =
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintVersion" }
+nmcpAggregation = { id = "com.gradleup.nmcp.aggregation", version.ref = "nmcp" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -124,6 +124,16 @@ publishing {
             }
         }
     }
+
+    repositories {
+        maven("https://central.sonatype.com/repository/maven-snapshots/") {
+            name = "SonatypeSnapshot"
+            credentials {
+                username = System.getenv("SONATYPE_USER")
+                password = System.getenv("SONATYPE_PASSWORD")
+            }
+        }
+    }
 }
 
 signing {

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,8 +1,3 @@
-@file:OptIn(ExperimentalEncodingApi::class)
-
-import kotlin.io.encoding.Base64
-import kotlin.io.encoding.ExperimentalEncodingApi
-
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
@@ -89,10 +84,6 @@ val dokkaJar = tasks.register<Jar>("dokkaJar") {
     archiveClassifier.set("javadoc")
 }
 
-val base64EncodedBearerToken = Base64.encode(
-    "${System.getenv("SONATYPE_USER")}:${System.getenv("SONATYPE_PASSWORD")}".toByteArray(),
-)
-
 publishing {
     // Workaround for the Android target
     // withType<MavenPublication> does not work for Android target
@@ -133,26 +124,6 @@ publishing {
             }
         }
     }
-
-    repositories {
-        maven("https://central.sonatype.com/repository/maven-snapshots/") {
-            name = "SonatypeSnapshot"
-            credentials {
-                username = System.getenv("SONATYPE_USER")
-                password = System.getenv("SONATYPE_PASSWORD")
-            }
-        }
-        maven("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/") {
-            name = "SonatypeStaging"
-            credentials(HttpHeaderCredentials::class) {
-                name = "Authorization"
-                value = "Bearer $base64EncodedBearerToken"
-            }
-            authentication {
-                create<HttpHeaderAuthentication>("header")
-            }
-        }
-    }
 }
 
 signing {
@@ -170,19 +141,4 @@ signing {
 tasks.withType<AbstractPublishToMaven>().configureEach {
     val signingTasks = tasks.withType<Sign>()
     mustRunAfter(signingTasks)
-}
-
-tasks.register<Exec>("moveOssrhStagingToCentralPortal") {
-    group = "publishing"
-    description = "Runs after publishAllPublicationsToSonatypeStagingRepository to move the artifacts to the central portal"
-
-    shouldRunAfter("publishAllPublicationsToSonatypeStagingRepository")
-
-    commandLine = listOf(
-        "curl",
-        "-f",
-        "-X", "POST",
-        "-H", "Authorization: Bearer $base64EncodedBearerToken",
-        "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/com.ioki",
-    )
 }

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -55,10 +55,6 @@ val dokkaJar = tasks.register<Jar>("dokkaJar") {
     archiveClassifier.set("javadoc")
 }
 
-val base64EncodedBearerToken = Base64.encode(
-    "${System.getenv("SONATYPE_USER")}:${System.getenv("SONATYPE_PASSWORD")}".toByteArray(),
-)
-
 publishing {
     // Workaround for the Android target
     // withType<MavenPublication> does not work for Android target
@@ -99,26 +95,6 @@ publishing {
             }
         }
     }
-
-    repositories {
-        maven("https://central.sonatype.com/repository/maven-snapshots/") {
-            name = "SonatypeSnapshot"
-            credentials {
-                username = System.getenv("SONATYPE_USER")
-                password = System.getenv("SONATYPE_PASSWORD")
-            }
-        }
-        maven("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/") {
-            name = "SonatypeStaging"
-            credentials(HttpHeaderCredentials::class) {
-                name = "Authorization"
-                value = "Bearer $base64EncodedBearerToken"
-            }
-            authentication {
-                create<HttpHeaderAuthentication>("header")
-            }
-        }
-    }
 }
 
 signing {
@@ -136,19 +112,4 @@ signing {
 tasks.withType<AbstractPublishToMaven>().configureEach {
     val signingTasks = tasks.withType<Sign>()
     mustRunAfter(signingTasks)
-}
-
-tasks.register<Exec>("moveOssrhStagingToCentralPortal") {
-    group = "publishing"
-    description = "Runs after publishAllPublicationsToSonatypeStagingRepository to move the artifacts to the central portal"
-
-    shouldRunAfter("publishAllPublicationsToSonatypeStagingRepository")
-
-    commandLine = listOf(
-        "curl",
-        "-f",
-        "-X", "POST",
-        "-H", "Authorization: Bearer $base64EncodedBearerToken",
-        "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/com.ioki",
-    )
 }

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -95,6 +95,16 @@ publishing {
             }
         }
     }
+
+     repositories {
+        maven("https://central.sonatype.com/repository/maven-snapshots/") {
+            name = "SonatypeSnapshot"
+            credentials {
+                username = System.getenv("SONATYPE_USER")
+                password = System.getenv("SONATYPE_PASSWORD")
+            }
+        }
+    }
 }
 
 signing {

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -96,7 +96,7 @@ publishing {
         }
     }
 
-     repositories {
+    repositories {
         maven("https://central.sonatype.com/repository/maven-snapshots/") {
             name = "SonatypeSnapshot"
             credentials {


### PR DESCRIPTION
Follow-up of #140 

## Description
<!--- Describe your changes -->
For whatever reasons, the current implementation didn't published *all* artifacts to the OSSRH staging, or then moved not all from there to the central portal 🤷 
Anyways, there were just artifacts left out.
Because I coun't find the root cause of it, I decided to switch to this plugin.
I tried it, and it just works 🙃 
