### PR TITLE
ApiPurchaseResponse: Replace deprecated `invoices` with `invoice`

### DIFF
--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiPurchaseResponse.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiPurchaseResponse.kt
@@ -25,7 +25,7 @@ public data class ApiPurchaseResponse(
     val state: ApiPurchaseState,
     val amount: ApiMoney,
     val reason: String?,
-    val invoices: List<Invoice>,
+    val invoice: Invoice?,
 ) {
     @Serializable
     public data class ChargeSplits(

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPurchaseResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPurchaseResponseTest.kt
@@ -52,15 +52,13 @@ internal class ApiPurchaseResponseTest : IokiApiModelTest() {
                 state = ApiPurchaseState.SUCCEEDED,
                 amount = createApiMoney(amount = 100, currency = "EUR"),
                 reason = "reason123",
-                invoices = listOf(
-                    ApiPurchaseResponse.Invoice(
-                        id = "invoiceId",
-                        userId = "userId",
-                        purchaseId = "purchaseId",
-                        attachmentUrl = "https://example.com/invoice.pdf",
-                        createdAt = Instant.parse("2023-07-19T13:17:42Z"),
-                        updatedAt = Instant.parse("2023-07-20T13:17:42Z"),
-                    ),
+                invoice = ApiPurchaseResponse.Invoice(
+                    id = "invoiceId",
+                    userId = "userId",
+                    purchaseId = "purchaseId",
+                    attachmentUrl = "https://example.com/invoice.pdf",
+                    createdAt = Instant.parse("2023-07-19T13:17:42Z"),
+                    updatedAt = Instant.parse("2023-07-20T13:17:42Z"),
                 ),
             ),
             purchaseResponse,
@@ -79,7 +77,7 @@ internal class ApiPurchaseResponseTest : IokiApiModelTest() {
                 chargeSplits = emptyList(),
                 state = ApiPurchaseState.PENDING,
                 amount = ApiMoney(amount = 25, currency = "USD"),
-                invoices = emptyList(),
+                invoice = null,
                 purchasableTitle = null,
                 purchasableDescription = null,
                 reason = null,
@@ -154,16 +152,14 @@ private val purchaseResponse =
         "currency": "EUR"
     },
     "reason": "reason123",
-    "invoices": [
-        {
-            "id": "invoiceId",
-            "user_id": "userId",
-            "purchase_id": "purchaseId",
-            "attachment_url": "https://example.com/invoice.pdf",
-            "created_at": "2023-07-19T13:17:42Z",
-            "updated_at": "2023-07-20T13:17:42Z"
-        }
-    ]
+    "invoice": {
+        "id": "invoiceId",
+        "user_id": "userId",
+        "purchase_id": "purchaseId",
+        "attachment_url": "https://example.com/invoice.pdf",
+        "created_at": "2023-07-19T13:17:42Z",
+        "updated_at": "2023-07-20T13:17:42Z"
+    }
 }
 """
 
@@ -180,7 +176,6 @@ private val purchaseResponseMinimal =
     "amount": {
         "amount": 25,
         "currency": "USD"
-    },
-    "invoices": []
+    }
 }
 """

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiPurchaseResponse.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiPurchaseResponse.kt
@@ -31,7 +31,7 @@ public fun createApiPurchaseResponse(
     paymentMethod: ApiPaymentMethodResponse? = null,
     chargeSplits: List<ChargeSplits> = emptyList(),
     amount: ApiMoney = createApiMoney(),
-    invoices: List<Invoice> = emptyList(),
+    invoice: Invoice? = null,
 ): ApiPurchaseResponse = ApiPurchaseResponse(
     id = id,
     purchasableId = purchasableId,
@@ -52,5 +52,5 @@ public fun createApiPurchaseResponse(
     state = state,
     amount = amount,
     reason = reason,
-    invoices = invoices,
+    invoice = invoice,
 )


### PR DESCRIPTION
## Description
<!--- Describe your changes -->

`ApiPurchaseResponse`: Replace deprecated `invoices` with `invoice`

## Test artifact

**Test models updated?**

In case you created a new APIObject or extracted one,
make sure to update the test fakes in [`test/src/commonMain/models`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test/models) as well.

Changes to existing models will probably fail on testing and are noticed by the CI.

**Test services updated?**

In case you created a new service or extracted one,
make sure to update the test fakes in [`test/src/commonMain/services`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test) as well.

Changes to existing services will probably fail on testing and are noticed by the CI.
