### PR TITLE
Revert "Bump kotlin from 2.1.21 to 2.2.0 (#159)"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.11.0"
-kotlin = "2.2.0"
+kotlin = "2.1.21"
 kotlinx-serialization = "1.8.1"
 kotlinx-datetime = "0.6.2"
 dokka = "2.0.0"


### PR DESCRIPTION
Internally, we run into https://github.com/google/dagger/issues/4779, so reverting back to 2.1.21 should fix it...