### PR TITLE
Replace kotlinx.datetime.Instant with kotlin.time.Instant 

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.11.0"
 kotlin = "2.2.0"
-kotlinx-serialization = "1.8.1"
+kotlinx-serialization = "1.9.0"
 kotlinx-datetime = "0.7.1"
 dokka = "2.0.0"
 ktor = "3.2.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.11.0"
 kotlin = "2.2.0"
 kotlinx-serialization = "1.8.1"
-kotlinx-datetime = "0.6.2"
+kotlinx-datetime = "0.7.1"
 dokka = "2.0.0"
 ktor = "3.2.1"
 ktlintVersion = "12.3.0"

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -24,6 +24,10 @@ kotlin {
     macosX64()
     macosArm64()
 
+    compilerOptions {
+        optIn.add("kotlin.time.ExperimentalTime")
+    }
+
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/library/src/appleMain/kotlin/com/ioki/passenger/api/internal/utils/Actuals.apple.kt
+++ b/library/src/appleMain/kotlin/com/ioki/passenger/api/internal/utils/Actuals.apple.kt
@@ -2,7 +2,7 @@ package com.ioki.passenger.api.internal.utils
 
 import io.ktor.client.network.sockets.SocketTimeoutException
 import io.ktor.client.plugins.HttpRequestTimeoutException
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/IokiService.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/IokiService.kt
@@ -90,7 +90,7 @@ import com.ioki.result.Result
 import io.ktor.client.call.body
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.isSuccess
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlin.coroutines.cancellation.CancellationException
 
 public fun IokiService(

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/internal/api/IokiApi.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/internal/api/IokiApi.kt
@@ -50,7 +50,7 @@ import io.ktor.client.request.url
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.parameters
 import io.ktor.util.StringValues
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.json.Json
 
 internal class IokiApi(

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/internal/utils/JsonHelper.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/internal/utils/JsonHelper.kt
@@ -2,7 +2,7 @@ package com.ioki.passenger.api.internal.utils
 
 import com.ioki.passenger.api.models.ApiFailedPaymentResponse
 import com.ioki.passenger.api.models.ApiFirebaseDebugRecordRequest
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/AnyValue.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/AnyValue.kt
@@ -1,9 +1,10 @@
 package com.ioki.passenger.api.models
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 import kotlinx.serialization.encoding.Decoder

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiAnnouncement.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiAnnouncement.kt
@@ -1,6 +1,6 @@
 package com.ioki.passenger.api.models
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiCancellationVoucherResponse.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiCancellationVoucherResponse.kt
@@ -1,6 +1,6 @@
 package com.ioki.passenger.api.models
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiFailedPaymentResponse.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiFailedPaymentResponse.kt
@@ -1,6 +1,6 @@
 package com.ioki.passenger.api.models
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiLocation.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiLocation.kt
@@ -1,6 +1,6 @@
 package com.ioki.passenger.api.models
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiMarketingResponse.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiMarketingResponse.kt
@@ -1,6 +1,6 @@
 package com.ioki.passenger.api.models
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiPersonalDiscountResponse.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiPersonalDiscountResponse.kt
@@ -1,6 +1,6 @@
 package com.ioki.passenger.api.models
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiPurchaseFilter.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiPurchaseFilter.kt
@@ -1,6 +1,6 @@
 package com.ioki.passenger.api.models
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiPurchaseResponse.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiPurchaseResponse.kt
@@ -1,6 +1,6 @@
 package com.ioki.passenger.api.models
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiRedeemedPromoCodeResponse.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiRedeemedPromoCodeResponse.kt
@@ -1,6 +1,6 @@
 package com.ioki.passenger.api.models
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiRideInquiryRequest.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiRideInquiryRequest.kt
@@ -1,6 +1,6 @@
 package com.ioki.passenger.api.models
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiRideInquiryResponse.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiRideInquiryResponse.kt
@@ -1,7 +1,7 @@
 package com.ioki.passenger.api.models
 
 import com.ioki.passenger.api.models.ApiRideInquiryResponse.Assistance.ErrorCode
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiRideResponse.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiRideResponse.kt
@@ -1,6 +1,6 @@
 package com.ioki.passenger.api.models
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiRideSeriesResponse.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiRideSeriesResponse.kt
@@ -1,6 +1,6 @@
 package com.ioki.passenger.api.models
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiScheduleResponse.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiScheduleResponse.kt
@@ -1,6 +1,6 @@
 package com.ioki.passenger.api.models
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiTicketingProductResponse.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiTicketingProductResponse.kt
@@ -1,6 +1,6 @@
 package com.ioki.passenger.api.models
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiTicketingVoucherResponse.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiTicketingVoucherResponse.kt
@@ -1,6 +1,6 @@
 package com.ioki.passenger.api.models
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/internal/api/IokiApiParametersTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/internal/api/IokiApiParametersTest.kt
@@ -14,9 +14,9 @@ import io.ktor.http.Parameters
 import io.ktor.util.toMap
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlin.test.Test
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 class IokiApiParametersTest {
 

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/internal/plugins/DateHeaderPluginTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/internal/plugins/DateHeaderPluginTest.kt
@@ -11,7 +11,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headers
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/AnyValueTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/AnyValueTest.kt
@@ -1,6 +1,6 @@
 package com.ioki.passenger.api.models
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlin.test.Test

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiLocationTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiLocationTest.kt
@@ -2,7 +2,7 @@ package com.ioki.passenger.api.models
 
 import com.ioki.passenger.api.test.models.createApiLocation
 import io.kotest.matchers.shouldBe
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlin.test.Test
 
 internal class ApiLocationTest : IokiApiModelTest() {

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPersonalDiscountResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPersonalDiscountResponseTest.kt
@@ -1,6 +1,6 @@
 package com.ioki.passenger.api.models
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlin.test.Test
 
 internal class ApiPersonalDiscountResponseTest : IokiApiModelTest() {

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiProductTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiProductTest.kt
@@ -2,7 +2,7 @@ package com.ioki.passenger.api.models
 
 import com.ioki.passenger.api.test.models.createApiAnnouncement
 import com.ioki.passenger.api.test.models.createApiStationResponse
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlin.test.Test
 
 internal class ApiProductTest : IokiApiModelTest() {

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPurchaseResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiPurchaseResponseTest.kt
@@ -3,7 +3,7 @@ package com.ioki.passenger.api.models
 import com.ioki.passenger.api.test.models.createApiMoney
 import com.ioki.passenger.api.test.models.createApiPaymentMethodResponseSummary
 import kotlin.test.Test
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 internal class ApiPurchaseResponseTest : IokiApiModelTest() {
     @Test

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRedeemedPromoCodeResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRedeemedPromoCodeResponseTest.kt
@@ -1,6 +1,6 @@
 package com.ioki.passenger.api.models
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlin.test.Test
 
 internal class ApiRedeemedPromoCodeResponseTest : IokiApiModelTest() {

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideInquiryRequestTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideInquiryRequestTest.kt
@@ -1,6 +1,6 @@
 package com.ioki.passenger.api.models
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlin.test.Test
 
 internal class ApiRideInquiryRequestTest : IokiApiModelTest() {

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideInquiryResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideInquiryResponseTest.kt
@@ -1,6 +1,6 @@
 package com.ioki.passenger.api.models
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlin.test.Test
 
 internal class ApiRideInquiryResponseTest : IokiApiModelTest() {

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideResponseTest.kt
@@ -3,7 +3,7 @@ package com.ioki.passenger.api.models
 import com.ioki.passenger.api.test.models.createApiFareResponse
 import com.ioki.passenger.api.test.models.createApiLocation
 import com.ioki.passenger.api.test.models.createApiVehicle
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlin.test.Test
 
 internal class ApiRideResponseTest : IokiApiModelTest() {

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideSeriesResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideSeriesResponseTest.kt
@@ -1,7 +1,7 @@
 package com.ioki.passenger.api.models
 
 import com.ioki.passenger.api.test.models.createApiLocation
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 import kotlin.test.Test
 

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiTicketingVoucherResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiTicketingVoucherResponseTest.kt
@@ -1,6 +1,6 @@
 package com.ioki.passenger.api.models
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlin.test.Test
 
 internal class ApiTicketingVoucherResponseTest : IokiApiModelTest() {

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -29,6 +29,10 @@ kotlin {
     macosX64()
     macosArm64()
 
+    compilerOptions {
+        optIn.add("kotlin.time.ExperimentalTime")
+    }
+
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/FakePublicTransportService.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/FakePublicTransportService.kt
@@ -3,7 +3,7 @@ package com.ioki.passenger.api.test
 import com.ioki.passenger.api.PublicTransportService
 import com.ioki.passenger.api.models.ApiScheduleResponse
 import com.ioki.passenger.api.result.ApiResult
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 public open class FakePublicTransportService : PublicTransportService {
     override suspend fun getPublicTransportSchedules(url: String, time: Instant): ApiResult<List<ApiScheduleResponse>> =

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiAnnouncement.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiAnnouncement.kt
@@ -1,7 +1,7 @@
 package com.ioki.passenger.api.test.models
 
 import com.ioki.passenger.api.models.ApiAnnouncement
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 public fun createApiAnnouncement(
     id: String = "",

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiCancellationVoucherResponse.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiCancellationVoucherResponse.kt
@@ -2,7 +2,7 @@ package com.ioki.passenger.api.test.models
 
 import com.ioki.passenger.api.models.ApiCancellationVoucherResponse
 import com.ioki.passenger.api.models.ApiMoney
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 public fun createApiCancellationVoucherResponse(
     type: String = "",

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiLocation.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiLocation.kt
@@ -2,7 +2,7 @@ package com.ioki.passenger.api.test.models
 
 import com.ioki.passenger.api.models.ApiLocation
 import com.ioki.passenger.api.models.ApiStationResponse
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 public fun createApiLocation(
     lat: Double = 0.0,

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiMarketingResponse.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiMarketingResponse.kt
@@ -2,7 +2,7 @@ package com.ioki.passenger.api.test.models
 
 import com.ioki.passenger.api.models.ApiAuthenticatedUserResponse
 import com.ioki.passenger.api.models.ApiMarketingResponse
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 public fun createApiMarketingResponse(
     id: String = "",

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiPersonalDiscountResponse.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiPersonalDiscountResponse.kt
@@ -2,7 +2,7 @@ package com.ioki.passenger.api.test.models
 
 import com.ioki.passenger.api.models.ApiMoney
 import com.ioki.passenger.api.models.ApiPersonalDiscountResponse
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 public fun createApiPersonalDiscountResponse(
     id: String = "",

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiPurchaseResponse.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiPurchaseResponse.kt
@@ -9,7 +9,7 @@ import com.ioki.passenger.api.models.ApiPurchaseResponse.CreatorType
 import com.ioki.passenger.api.models.ApiPurchaseResponse.Invoice
 import com.ioki.passenger.api.models.ApiPurchaseState
 import com.ioki.passenger.api.models.ApiPurchaseType
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 public fun createApiPurchaseResponse(
     id: String = "",

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiRedeemedPromoCodeResponse.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiRedeemedPromoCodeResponse.kt
@@ -1,7 +1,7 @@
 package com.ioki.passenger.api.test.models
 
 import com.ioki.passenger.api.models.ApiRedeemedPromoCodeResponse
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 public fun createApiRedeemedPromoCodeResponse(
     id: String = "",

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiRideInquiryRequest.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiRideInquiryRequest.kt
@@ -2,7 +2,7 @@ package com.ioki.passenger.api.test.models
 
 import com.ioki.passenger.api.models.ApiPassengerSelectionRequest
 import com.ioki.passenger.api.models.ApiRideInquiryRequest
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 public fun createApiRideInquiryRequest(
     productId: String = "",

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiRideInquiryResponse.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiRideInquiryResponse.kt
@@ -3,7 +3,7 @@ package com.ioki.passenger.api.test.models
 import com.ioki.passenger.api.models.ApiArea
 import com.ioki.passenger.api.models.ApiRideInquiryResponse
 import com.ioki.passenger.api.models.ApiRideInquiryResponse.Assistance.ErrorCode
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 public fun createApiRideInquiryResponse(
     availability: ApiRideInquiryResponse.Availability = createApiRideInquiryResponseAvailability(),

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiRideResponse.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiRideResponse.kt
@@ -14,7 +14,7 @@ import com.ioki.passenger.api.models.ApiRatingResponse
 import com.ioki.passenger.api.models.ApiRideResponse
 import com.ioki.passenger.api.models.ApiTipResponse
 import com.ioki.passenger.api.models.ApiVehicle
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 public fun createApiRideResponse(
     id: String = "",

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiRideSeriesResponse.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiRideSeriesResponse.kt
@@ -2,7 +2,7 @@ package com.ioki.passenger.api.test.models
 
 import com.ioki.passenger.api.models.ApiRideResponse
 import com.ioki.passenger.api.models.ApiRideSeriesResponse
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 
 public fun createApiRideSeriesResponse(

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiScheduleResponse.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiScheduleResponse.kt
@@ -2,7 +2,7 @@ package com.ioki.passenger.api.test.models
 
 import com.ioki.passenger.api.models.ApiPublicTransportType
 import com.ioki.passenger.api.models.ApiScheduleResponse
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 public fun createApiScheduleResponse(
     transportType: ApiPublicTransportType = ApiPublicTransportType.UNSUPPORTED,

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiTicketingProductResponse.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiTicketingProductResponse.kt
@@ -3,7 +3,7 @@ package com.ioki.passenger.api.test.models
 import com.ioki.passenger.api.models.ApiMoney
 import com.ioki.passenger.api.models.ApiTicketingProductOption
 import com.ioki.passenger.api.models.ApiTicketingProductResponse
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 public fun createApiTicketingProductResponse(
     id: String? = null,

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiTicketingVoucherResponse.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiTicketingVoucherResponse.kt
@@ -3,7 +3,7 @@ package com.ioki.passenger.api.test.models
 import com.ioki.passenger.api.models.ApiMoney
 import com.ioki.passenger.api.models.ApiTicketingProductResponse
 import com.ioki.passenger.api.models.ApiTicketingVoucherResponse
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 public fun createApiTicketingVoucherResponse(
     id: String = "",


### PR DESCRIPTION
## Related Issue
<!--- If this is a feature or a bug fix, make sure to link the related issue here -->
closes https://github.com/dbdrive/beiwagen-android/issues/7762

closes #166 

## Description
<!--- Describe your changes -->
 * Update kotlin datetime to 0.7.1
 * Replace imports for Instant and Clock
 * Fix Instant serialization

## Test artifact

**Test models updated?** Yes

In case you created a new APIObject or extracted one,
make sure to update the test fakes in [`test/src/commonMain/models`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test/models) as well.

Changes to existing models will probably fail on testing and are noticed by the CI.

**Test services updated?**

In case you created a new service or extracted one,
make sure to update the test fakes in [`test/src/commonMain/services`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test) as well.

Changes to existing services will probably fail on testing and are noticed by the CI.
