### PR TITLE
Fix toolchains

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -13,7 +13,10 @@ kotlin {
 
     applyDefaultHierarchyTemplate()
 
-    jvmToolchain(17)
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+        vendor.set(JvmVendorSpec.ADOPTIUM)
+    }
 
     jvm()
     androidLibrary {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 dependencyResolutionManagement {
     repositories {
         google()

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -13,7 +13,10 @@ kotlin {
 
     applyDefaultHierarchyTemplate()
 
-    jvmToolchain(17)
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+        vendor.set(JvmVendorSpec.ADOPTIUM)
+    }
 
     jvm()
     androidLibrary {


### PR DESCRIPTION
## Description
<!--- Describe your changes -->

We defined the jvmToolchain to be 17.
However, if not installed on a machine, we fail.
It tries to locate any java 17 installation, but can't find them.
I added a jvm resolver plugin to solve this.
If there is no local jvm available, it will download it for you from the foojay service.

## Test artifact

**Test models updated?**

In case you created a new APIObject or extracted one,
make sure to update the test fakes in [`test/src/commonMain/models`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test/models) as well.

Changes to existing models will probably fail on testing and are noticed by the CI.

**Test services updated?**

In case you created a new service or extracted one,
make sure to update the test fakes in [`test/src/commonMain/services`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test) as well.

Changes to existing services will probably fail on testing and are noticed by the CI.
