### PR TITLE
Add solutionType to ApiOfferedSolution

### DIFF
--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiOfferedSolution.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiOfferedSolution.kt
@@ -16,7 +16,20 @@ public data class ApiOfferedSolution(
     val bookable: Boolean,
     val fare: ApiFareResponse?,
     val hops: List<Hop>,
+    @SerialName(value = "solution_type") val solutionType: SolutionType,
 ) {
+    public enum class SolutionType {
+        @SerialName(value = "drt")
+        DRT,
+
+        @SerialName(value = "public_transport")
+        PUBLIC_TRANSPORT,
+
+        @SerialName(value = "intermodal")
+        INTERMODAL,
+        UNSUPPORTED,
+    }
+
     @Serializable
     public data class Hop(
         @SerialName(value = "transport_mode")

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideResponseTest.kt
@@ -167,6 +167,7 @@ internal class ApiRideResponseTest : IokiApiModelTest() {
                                 details = null,
                             ),
                         ),
+                        solutionType = ApiOfferedSolution.SolutionType.DRT,
                     ),
                 ),
                 bookedSolution = ApiOfferedSolution(
@@ -208,6 +209,7 @@ internal class ApiRideResponseTest : IokiApiModelTest() {
                             details = null,
                         ),
                     ),
+                    solutionType = ApiOfferedSolution.SolutionType.DRT,
                 ),
                 passengerNoteToDriver = "This is a note to the driver",
                 showPublicTransportTicketReminder = true,

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideResponseTest.kt
@@ -497,7 +497,8 @@ private val rideResponse =
             "door_control_available": false
           }
         }
-      ]
+      ],
+      "solution_type": "drt",
     }
   ],
   "booked_solution": {
@@ -544,7 +545,8 @@ private val rideResponse =
             "door_control_available": false
           }
         }
-      ]
+      ],
+      "solution_type": "drt",
     },
     "passenger_note_to_driver": "This is a note to the driver",
     "show_pt_ticket_reminder": true,

--- a/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideResponseTest.kt
+++ b/library/src/commonTest/kotlin/com/ioki/passenger/api/models/ApiRideResponseTest.kt
@@ -498,7 +498,7 @@ private val rideResponse =
           }
         }
       ],
-      "solution_type": "drt",
+      "solution_type": "drt"
     }
   ],
   "booked_solution": {
@@ -546,7 +546,7 @@ private val rideResponse =
           }
         }
       ],
-      "solution_type": "drt",
+      "solution_type": "drt"
     },
     "passenger_note_to_driver": "This is a note to the driver",
     "show_pt_ticket_reminder": true,

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiOfferedSolution.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiOfferedSolution.kt
@@ -12,12 +12,14 @@ public fun createApiOfferedSolution(
     bookable: Boolean = false,
     fare: ApiFareResponse? = null,
     hops: List<ApiOfferedSolution.Hop> = emptyList(),
+    solutionType: ApiOfferedSolution.SolutionType = ApiOfferedSolution.SolutionType.UNSUPPORTED,
 ): ApiOfferedSolution = ApiOfferedSolution(
     type = type,
     id = id,
     bookable = bookable,
     fare = fare,
     hops = hops,
+    solutionType = solutionType,
 )
 
 public fun createApiOfferedSolutionHop(


### PR DESCRIPTION
## Related Issue
<!--- If this is a feature or a bug fix, make sure to link the related issue here -->
Related to https://github.com/dbdrive/beiwagen-android/issues/8515

## Description
<!--- Describe your changes -->
- Adds `solutionType` to `ApiOfferedSolution`

## Test artifact

**Test models updated?**

In case you created a new APIObject or extracted one,
make sure to update the test fakes in [`test/src/commonMain/models`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test/models) as well.

Changes to existing models will probably fail on testing and are noticed by the CI.

**Test services updated?**

In case you created a new service or extracted one,
make sure to update the test fakes in [`test/src/commonMain/services`](../test/src/commonMain/kotlin/com/ioki/passenger/api/test) as well.

Changes to existing services will probably fail on testing and are noticed by the CI.
