### PR TITLE
Update ApiVerificationResponse with channel and email_address fields

### DIFF
--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiVerificationResponse.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiVerificationResponse.kt
@@ -5,7 +5,9 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 public data class ApiVerificationResponse(
-    @SerialName(value = "phone_number") val phoneNumber: String,
+    val channel: ApiVerificationChannelType,
+    @SerialName(value = "email_address") val emailAddress: String?,
+    @SerialName(value = "phone_number") val phoneNumber: String?,
     val captcha: Captcha?,
     @SerialName(value = "client_challenge") val clientChallenge: ClientChallenge?,
 ) {

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiVerificationResponse.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiVerificationResponse.kt
@@ -1,12 +1,17 @@
 package com.ioki.passenger.api.test.models
 
+import com.ioki.passenger.api.models.ApiVerificationChannelType
 import com.ioki.passenger.api.models.ApiVerificationResponse
 
 public fun createApiVerificationResponse(
-    phoneNumber: String = "",
+    channel: ApiVerificationChannelType = ApiVerificationChannelType.UNSUPPORTED,
+    emailAddress: String? = null,
+    phoneNumber: String? = null,
     captcha: ApiVerificationResponse.Captcha? = null,
     clientChallenge: ApiVerificationResponse.ClientChallenge? = null,
 ): ApiVerificationResponse = ApiVerificationResponse(
+    channel = channel,
+    emailAddress = emailAddress,
     phoneNumber = phoneNumber,
     captcha = captcha,
     clientChallenge = clientChallenge,


### PR DESCRIPTION
## Summary
Updates `ApiVerificationResponse` to match the latest API spec changes:
- Adds `channel` (`ApiVerificationChannelType`)
- Adds nullable `email_address`
- Makes `phone_number` nullable
- Skips `id`, `created_at`, `updated_at`, `type` fields (not needed)
- Updates the test helper builder in the `test` package accordingly

## Testing
- `./gradlew ktlintCommonTestSourceSetCheck ktlintCommonMainSourceSetCheck jvmTest` — all passing