### PR TITLE
Update ApiAuthenticatedUserResponse for email-login support

### DIFF
--- a/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiAuthenticatedUserResponse.kt
+++ b/library/src/commonMain/kotlin/com/ioki/passenger/api/models/ApiAuthenticatedUserResponse.kt
@@ -10,7 +10,7 @@ public data class ApiAuthenticatedUserResponse(
     @SerialName(value = "last_name") val lastName: String?,
     val registered: Boolean,
     override val version: Int,
-    @SerialName(value = "phone_number") val phoneNumber: String,
+    @SerialName(value = "phone_number") val phoneNumber: String?,
     @SerialName(value = "phone_number_verified") val phoneNumberVerified: Boolean,
     @SerialName(value = "email_address") val emailAddress: String?,
     @SerialName(value = "email_address_verified") val emailAddressVerified: Boolean,

--- a/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiAuthenticatedUserResponse.kt
+++ b/test/src/commonMain/kotlin/com/ioki/passenger/api/test/models/ApiAuthenticatedUserResponse.kt
@@ -8,7 +8,7 @@ public fun createApiAuthenticatedUserResponse(
     lastName: String? = null,
     registered: Boolean = false,
     version: Int = 0,
-    phoneNumber: String = "",
+    phoneNumber: String? = null,
     phoneNumberVerified: Boolean = false,
     emailAddress: String? = null,
     emailAddressVerified: Boolean = false,


### PR DESCRIPTION
## Summary
Makes `phone_number` nullable in `ApiAuthenticatedUserResponse` (email-only login accounts may not have a phone number).

## Testing
- `./gradlew ktlintCommonTestSourceSetCheck ktlintCommonMainSourceSetCheck jvmTest` — all passing
